### PR TITLE
Add local domain support for development (*.localhost)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,8 @@ just format                 # Format code
 just dev                    # Start full dev environment (Phoenix + Frontend + Caddy)
 just worktree name          # Create isolated dev environment
 just worktree-setup         # Setup current worktree (run after checkout)
-just ports                  # Show port configuration for current worktree
+just ports                  # Show port and domain configuration for current worktree
+just dns-setup              # One-time setup for local *.localhost domain resolution
 ```
 
 ## Code Generation
@@ -172,6 +173,40 @@ This updates `frontend/src/sdk/ash_rpc.ts` with typed RPC functions.
 - Frontend default: port 3000 (auto-increments if taken)
 - Use `PORT=4001` for additional backend instances
 - Use `DISABLE_LIVE_DEBUGGER=true` to avoid port conflicts
+
+## Local Domain Setup (Recommended)
+
+For a better development experience, you can use custom local domains like `https://streampai.my-branch.localhost` instead of `https://localhost:8000`.
+
+### One-Time DNS Setup
+
+Run this once on your machine to enable `*.localhost` domain resolution:
+
+```bash
+just dns-setup
+```
+
+This installs and configures `dnsmasq` to resolve all `*.localhost` domains to `127.0.0.1`.
+
+### How It Works
+
+When you run `just worktree-setup`, it automatically:
+1. Generates a local domain based on your branch name: `streampai.{branch-name}.localhost`
+2. Configures Caddy to listen on both the domain (port 443) and the fallback port
+3. Sets the `LOCAL_DOMAIN` environment variable in `.env`
+
+### Accessing Your App
+
+After running `just dev`:
+- **Recommended**: `https://streampai.my-branch.localhost` (clean URLs, no port)
+- **Fallback**: `https://localhost:8898` (random port, always works)
+
+### Benefits
+
+- **No port conflicts**: Each worktree uses a unique domain, no random ports to remember
+- **Cleaner URLs**: No port numbers in your development URLs
+- **OAuth-friendly**: Easier to configure OAuth redirect URIs with predictable domains
+- **Parallel development**: Run multiple worktrees simultaneously with distinct domains
 
 ## Worktree Setup (Isolated Development)
 
@@ -341,4 +376,4 @@ export const Default: Story = {
 - App name is "Streampai" (not "StreamPai")
 - If a port is taken, use another port instead of killing the running app
 - When using Playwright MCP for testing, let the user log in manually unless explicitly asked to automate it
-- **Playwright testing**: Always use HTTPS and the Caddy port (e.g., `https://localhost:8000`), not the direct frontend port. Caddy proxies both frontend and backend, which is required for auth flows to work correctly.
+- **Playwright testing**: Always use HTTPS and either the local domain (e.g., `https://streampai.my-branch.localhost`) or the Caddy port (e.g., `https://localhost:8000`), not the direct frontend port. Caddy proxies both frontend and backend, which is required for auth flows to work correctly.

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,12 +1,18 @@
 # Caddyfile for local development with HTTPS
 # This provides HTTPS for secure cookie handling and API testing.
 #
+# Supports two modes:
+# 1. Port-based (legacy): https://localhost:8000
+# 2. Domain-based: https://streampai.{branch}.localhost
+#
 # Usage:
 #   # Start Caddy:
 #   caddy run --config Caddyfile
 #
 # Or with environment variable override:
 #   CADDY_PORT=8080 PORT=4000 FRONTEND_PORT=3000 caddy run --config Caddyfile
+#
+# For domain-based access, set LOCAL_DOMAIN in .env (e.g., streampai.my-branch.localhost)
 #
 # Make sure to run `caddy trust` first to install local CA certificates.
 
@@ -15,6 +21,60 @@
 	auto_https disable_redirects
 }
 
+# Domain-based routing (when LOCAL_DOMAIN is set)
+# Uses standard HTTPS port 443 for cleaner URLs
+{$LOCAL_DOMAIN:} {
+	# Skip this block if LOCAL_DOMAIN is not set (empty matcher)
+	@domain_set expression `"{$LOCAL_DOMAIN}" != ""`
+
+	# All backend routes are prefixed with /api - proxy to Phoenix
+	handle /api/* {
+		reverse_proxy localhost:{$PORT:4000}
+	}
+
+	# Admin routes (internal only, not prefixed)
+	handle /admin/* {
+		reverse_proxy localhost:{$PORT:4000}
+	}
+
+	# Tidewave MCP for Claude integration
+	handle /tidewave/* {
+		reverse_proxy localhost:{$PORT:4000}
+	}
+
+	# Vite HMR WebSocket - client router
+	handle /_build/_hmr/client {
+		reverse_proxy localhost:{$FRONTEND_HMR_CLIENT_PORT:3001}
+	}
+
+	# Vite HMR WebSocket - server router
+	handle /_build/_hmr/server {
+		reverse_proxy localhost:{$FRONTEND_HMR_SERVER_PORT:3002}
+	}
+
+	# Vite HMR WebSocket - server-function router
+	handle /_build/_hmr/server-function {
+		reverse_proxy localhost:{$FRONTEND_HMR_SERVER_FUNCTION_PORT:3003}
+	}
+
+	# Vite dev server assets
+	handle /_build/* {
+		reverse_proxy localhost:{$FRONTEND_PORT:3000}
+	}
+
+	# Everything else goes to frontend
+	handle {
+		reverse_proxy localhost:{$FRONTEND_PORT:3000}
+	}
+
+	encode gzip
+	log {
+		output stdout
+		format console
+	}
+}
+
+# Port-based routing (fallback, always available)
 localhost:{$CADDY_PORT:8000} {
 	# All backend routes are prefixed with /api - proxy to Phoenix
 	handle /api/* {


### PR DESCRIPTION
## Summary

- Enable custom local domains like `https://streampai.branch-name.localhost` for a better development experience
- Each worktree automatically gets a unique domain based on its branch name
- No more remembering random port numbers - just use clean, predictable URLs

## Changes

- **DNS Setup**: Added `just dns-setup` command that installs and configures dnsmasq for `*.localhost` domain resolution
- **Caddyfile**: Updated to support domain-based routing on port 443, while keeping port-based fallback for compatibility
- **Worktree Setup**: Auto-generates `LOCAL_DOMAIN` environment variable (e.g., `streampai.my-branch.localhost`)
- **CORS**: Updated to dynamically allow all `*.localhost` origins instead of hardcoded list

## How to Use

1. One-time DNS setup: `just dns-setup` (requires sudo for dnsmasq)
2. Run `just worktree-setup` (or create new worktree) - domain is auto-configured
3. Start dev server: `just dev`
4. Access via `https://streampai.{branch-name}.localhost`

Fallback `https://localhost:{port}` still works for environments without DNS setup.

## Test plan

- [x] Verified DNS resolution works for `*.localhost` domains
- [x] Tested app loads at `https://streampai.daf0-see-if-we-can-so.localhost`
- [x] Verified fallback port `https://localhost:8898` still works
- [x] Confirmed CORS allows requests from local domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)