### PR TITLE
Migrate to design system components

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@ import { For } from "solid-js";
 import { LOCALE_NAMES, SUPPORTED_LOCALES, useI18n, type Locale } from "~/i18n";
 import { useCurrentUser } from "~/lib/auth";
 import { saveLanguagePreference } from "~/sdk/ash_rpc";
+import { Select } from "~/components/ui/Input";
 
 interface LanguageSwitcherProps {
 	class?: string;
@@ -32,10 +33,10 @@ export default function LanguageSwitcher(props: LanguageSwitcherProps) {
 	};
 
 	return (
-		<select
+		<Select
 			value={locale()}
 			onChange={(e) => handleLanguageChange(e.currentTarget.value as Locale)}
-			class={`rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500 ${props.class ?? ""}`}
+			class={props.class}
 			aria-label="Select language"
 			data-testid="language-switcher">
 			<For each={[...SUPPORTED_LOCALES]}>
@@ -43,6 +44,6 @@ export default function LanguageSwitcher(props: LanguageSwitcherProps) {
 					<option value={localeCode}>{LOCALE_NAMES[localeCode]}</option>
 				)}
 			</For>
-		</select>
+		</Select>
 	);
 }

--- a/frontend/src/components/StreamingAccountStats.tsx
+++ b/frontend/src/components/StreamingAccountStats.tsx
@@ -1,4 +1,6 @@
 import { createSignal, Show } from "solid-js";
+import Badge, { type BadgeVariant } from "~/components/ui/Badge";
+import Card from "~/components/ui/Card";
 
 export interface StreamingAccountData {
 	platform:
@@ -32,6 +34,7 @@ const platformConfig = {
 		bgColor: "bg-red-50",
 		textColor: "text-red-700",
 		borderColor: "border-red-200",
+		badgeVariant: "error" as BadgeVariant,
 	},
 	twitch: {
 		name: "Twitch",
@@ -39,6 +42,7 @@ const platformConfig = {
 		bgColor: "bg-purple-50",
 		textColor: "text-purple-700",
 		borderColor: "border-purple-200",
+		badgeVariant: "purple" as BadgeVariant,
 	},
 	facebook: {
 		name: "Facebook",
@@ -46,6 +50,7 @@ const platformConfig = {
 		bgColor: "bg-blue-50",
 		textColor: "text-blue-700",
 		borderColor: "border-blue-200",
+		badgeVariant: "info" as BadgeVariant,
 	},
 	kick: {
 		name: "Kick",
@@ -53,6 +58,7 @@ const platformConfig = {
 		bgColor: "bg-green-50",
 		textColor: "text-green-700",
 		borderColor: "border-green-200",
+		badgeVariant: "success" as BadgeVariant,
 	},
 	tiktok: {
 		name: "TikTok",
@@ -60,6 +66,7 @@ const platformConfig = {
 		bgColor: "bg-gray-50",
 		textColor: "text-gray-700",
 		borderColor: "border-gray-200",
+		badgeVariant: "neutral" as BadgeVariant,
 	},
 	trovo: {
 		name: "Trovo",
@@ -67,6 +74,7 @@ const platformConfig = {
 		bgColor: "bg-teal-50",
 		textColor: "text-teal-700",
 		borderColor: "border-teal-200",
+		badgeVariant: "success" as BadgeVariant,
 	},
 	instagram: {
 		name: "Instagram",
@@ -74,6 +82,7 @@ const platformConfig = {
 		bgColor: "bg-pink-50",
 		textColor: "text-pink-700",
 		borderColor: "border-pink-200",
+		badgeVariant: "pink" as BadgeVariant,
 	},
 	rumble: {
 		name: "Rumble",
@@ -81,6 +90,7 @@ const platformConfig = {
 		bgColor: "bg-green-50",
 		textColor: "text-green-700",
 		borderColor: "border-green-200",
+		badgeVariant: "success" as BadgeVariant,
 	},
 };
 
@@ -163,10 +173,9 @@ export default function StreamingAccountStats(
 							<span class="font-semibold text-gray-900">
 								{props.data.accountName}
 							</span>
-							<span
-								class={`rounded-full px-2 py-0.5 text-xs ${config().bgColor} ${config().textColor}`}>
+							<Badge variant={config().badgeVariant} size="sm">
 								{config().name}
-							</span>
+							</Badge>
 						</div>
 						<div class="text-gray-500 text-sm">Connected</div>
 					</div>
@@ -231,30 +240,30 @@ export default function StreamingAccountStats(
 			</div>
 
 			<div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
-				<div class="rounded-lg bg-white p-3 shadow-sm">
+				<Card padding="sm" class="rounded-lg">
 					<div class="text-gray-500 text-xs uppercase">Sponsors</div>
 					<div class="mt-1 font-bold text-gray-900 text-xl">
 						{formatNumber(props.data.sponsorCount)}
 					</div>
-				</div>
-				<div class="rounded-lg bg-white p-3 shadow-sm">
+				</Card>
+				<Card padding="sm" class="rounded-lg">
 					<div class="text-gray-500 text-xs uppercase">Views (30d)</div>
 					<div class="mt-1 font-bold text-gray-900 text-xl">
 						{formatNumber(props.data.viewsLast30d)}
 					</div>
-				</div>
-				<div class="rounded-lg bg-white p-3 shadow-sm">
+				</Card>
+				<Card padding="sm" class="rounded-lg">
 					<div class="text-gray-500 text-xs uppercase">Followers</div>
 					<div class="mt-1 font-bold text-gray-900 text-xl">
 						{formatNumber(props.data.followerCount)}
 					</div>
-				</div>
-				<div class="rounded-lg bg-white p-3 shadow-sm">
+				</Card>
+				<Card padding="sm" class="rounded-lg">
 					<div class="text-gray-500 text-xs uppercase">Subscribers</div>
 					<div class="mt-1 font-bold text-gray-900 text-xl">
 						{formatNumber(props.data.subscriberCount)}
 					</div>
-				</div>
+				</Card>
 			</div>
 
 			<div class="mt-3 flex items-center justify-between text-gray-500 text-xs">

--- a/frontend/src/components/WidgetSettingsPage.tsx
+++ b/frontend/src/components/WidgetSettingsPage.tsx
@@ -63,7 +63,9 @@ import type { WidgetType } from "~/lib/electric";
 import { SchemaForm, getDefaultValues, type FormMeta } from "~/lib/schema-form";
 import { useWidgetConfig } from "~/lib/useElectric";
 import { saveWidgetConfig } from "~/sdk/ash_rpc";
-import { button, card, text } from "~/styles/design-system";
+import Button from "~/components/ui/Button";
+import Card from "~/components/ui/Card";
+import { text } from "~/styles/design-system";
 
 /**
  * Convert camelCase to snake_case for backend
@@ -228,7 +230,7 @@ export function WidgetSettingsPage<T extends z.ZodRawShape, P = object>(
 			<Show when={ready()} fallback={<div>Loading...</div>}>
 				<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
 					{/* Configuration Form */}
-					<div class={card.default}>
+					<Card>
 						<h2 class={text.h2}>Configuration</h2>
 						<div class="mt-4 space-y-4">
 							<SchemaForm
@@ -249,18 +251,14 @@ export function WidgetSettingsPage<T extends z.ZodRawShape, P = object>(
 								</div>
 							</Show>
 
-							<button
-								type="button"
-								class={button.primary}
-								onClick={handleSave}
-								disabled={saving()}>
+							<Button type="button" onClick={handleSave} disabled={saving()}>
 								{saving() ? "Saving..." : "Save Configuration"}
-							</button>
+							</Button>
 						</div>
-					</div>
+					</Card>
 
 					{/* Preview */}
-					<div class={card.default}>
+					<Card>
 						<h2 class={text.h2}>Preview</h2>
 						<div class="mt-4 space-y-4">
 							{props.previewWrapper ? (
@@ -304,7 +302,7 @@ export function WidgetSettingsPage<T extends z.ZodRawShape, P = object>(
 								</ul>
 							</div>
 						</div>
-					</div>
+					</Card>
 				</div>
 			</Show>
 		</div>

--- a/frontend/src/lib/schema-form/fields/ColorField.tsx
+++ b/frontend/src/lib/schema-form/fields/ColorField.tsx
@@ -1,5 +1,6 @@
 import type { Component } from "solid-js";
-import { input, text } from "~/styles/design-system";
+import Input from "~/components/ui/Input";
+import { text } from "~/styles/design-system";
 import type { IntrospectedField } from "../types";
 
 interface ColorFieldProps {
@@ -22,9 +23,8 @@ export const ColorField: Component<ColorFieldProps> = (props) => {
 						onInput={(e) => props.onChange(e.currentTarget.value)}
 						disabled={props.disabled}
 					/>
-					<input
+					<Input
 						type="text"
-						class={input.text}
 						value={props.value ?? ""}
 						onInput={(e) => props.onChange(e.currentTarget.value)}
 						placeholder="#000000"

--- a/frontend/src/lib/schema-form/fields/NumberField.tsx
+++ b/frontend/src/lib/schema-form/fields/NumberField.tsx
@@ -1,5 +1,5 @@
 import type { Component } from "solid-js";
-import { input, text } from "~/styles/design-system";
+import Input from "~/components/ui/Input";
 import type { IntrospectedField } from "../types";
 
 interface NumberFieldProps {
@@ -10,32 +10,27 @@ interface NumberFieldProps {
 }
 
 export const NumberField: Component<NumberFieldProps> = (props) => {
+	const labelWithUnit = () => {
+		if (props.field.meta.unit) {
+			return `${props.field.label} (${props.field.meta.unit})`;
+		}
+		return props.field.label;
+	};
+
 	return (
-		<div>
-			<label class="block">
-				<span class={text.label}>
-					{props.field.label}
-					{props.field.meta.unit && (
-						<span class="ml-1 text-gray-400">({props.field.meta.unit})</span>
-					)}
-				</span>
-				<input
-					type="number"
-					class={`mt-1 ${input.text}`}
-					value={props.value ?? 0}
-					onInput={(e) => {
-						const val = parseFloat(e.currentTarget.value);
-						if (!isNaN(val)) props.onChange(val);
-					}}
-					min={props.field.min}
-					max={props.field.max}
-					step={props.field.meta.step ?? 1}
-					disabled={props.disabled}
-				/>
-			</label>
-			{props.field.meta.description && (
-				<p class={`mt-1 ${text.helper}`}>{props.field.meta.description}</p>
-			)}
-		</div>
+		<Input
+			type="number"
+			label={labelWithUnit()}
+			value={props.value ?? 0}
+			onInput={(e) => {
+				const val = Number.parseFloat(e.currentTarget.value);
+				if (!Number.isNaN(val)) props.onChange(val);
+			}}
+			min={props.field.min}
+			max={props.field.max}
+			step={props.field.meta.step ?? 1}
+			disabled={props.disabled}
+			helperText={props.field.meta.description}
+		/>
 	);
 };

--- a/frontend/src/lib/schema-form/fields/SelectField.tsx
+++ b/frontend/src/lib/schema-form/fields/SelectField.tsx
@@ -1,5 +1,5 @@
 import { For, type Component } from "solid-js";
-import { input, text } from "~/styles/design-system";
+import { Select } from "~/components/ui/Input";
 import type { IntrospectedField } from "../types";
 
 interface SelectFieldProps {
@@ -24,24 +24,15 @@ function enumValueToLabel(value: string): string {
 
 export const SelectField: Component<SelectFieldProps> = (props) => {
 	return (
-		<div>
-			<label class="block">
-				<span class={text.label}>{props.field.label}</span>
-				<select
-					class={`mt-1 ${input.select}`}
-					value={props.value ?? ""}
-					onChange={(e) => props.onChange(e.currentTarget.value)}
-					disabled={props.disabled}>
-					<For each={props.field.enumValues ?? []}>
-						{(option) => (
-							<option value={option}>{enumValueToLabel(option)}</option>
-						)}
-					</For>
-				</select>
-			</label>
-			{props.field.meta.description && (
-				<p class={`mt-1 ${text.helper}`}>{props.field.meta.description}</p>
-			)}
-		</div>
+		<Select
+			label={props.field.label}
+			value={props.value ?? ""}
+			onChange={(e) => props.onChange(e.currentTarget.value)}
+			disabled={props.disabled}
+			helperText={props.field.meta.description}>
+			<For each={props.field.enumValues ?? []}>
+				{(option) => <option value={option}>{enumValueToLabel(option)}</option>}
+			</For>
+		</Select>
 	);
 };

--- a/frontend/src/lib/schema-form/fields/TextField.tsx
+++ b/frontend/src/lib/schema-form/fields/TextField.tsx
@@ -1,5 +1,5 @@
 import type { Component } from "solid-js";
-import { input, text } from "~/styles/design-system";
+import Input from "~/components/ui/Input";
 import type { IntrospectedField } from "../types";
 
 interface TextFieldProps {
@@ -11,21 +11,14 @@ interface TextFieldProps {
 
 export const TextField: Component<TextFieldProps> = (props) => {
 	return (
-		<div>
-			<label class="block">
-				<span class={text.label}>{props.field.label}</span>
-				<input
-					type="text"
-					class={`mt-1 ${input.text}`}
-					value={props.value ?? ""}
-					onInput={(e) => props.onChange(e.currentTarget.value)}
-					placeholder={props.field.meta.placeholder}
-					disabled={props.disabled}
-				/>
-			</label>
-			{props.field.meta.description && (
-				<p class={`mt-1 ${text.helper}`}>{props.field.meta.description}</p>
-			)}
-		</div>
+		<Input
+			type="text"
+			label={props.field.label}
+			value={props.value ?? ""}
+			onInput={(e) => props.onChange(e.currentTarget.value)}
+			placeholder={props.field.meta.placeholder}
+			disabled={props.disabled}
+			helperText={props.field.meta.description}
+		/>
 	);
 };

--- a/frontend/src/lib/schema-form/fields/TextareaField.tsx
+++ b/frontend/src/lib/schema-form/fields/TextareaField.tsx
@@ -1,5 +1,5 @@
 import type { Component } from "solid-js";
-import { input, text } from "~/styles/design-system";
+import { Textarea } from "~/components/ui/Input";
 import type { IntrospectedField } from "../types";
 
 interface TextareaFieldProps {
@@ -11,21 +11,14 @@ interface TextareaFieldProps {
 
 export const TextareaField: Component<TextareaFieldProps> = (props) => {
 	return (
-		<div>
-			<label class="block">
-				<span class={text.label}>{props.field.label}</span>
-				<textarea
-					class={`mt-1 ${input.textarea}`}
-					rows={4}
-					value={props.value ?? ""}
-					onInput={(e) => props.onChange(e.currentTarget.value)}
-					placeholder={props.field.meta.placeholder}
-					disabled={props.disabled}
-				/>
-			</label>
-			{props.field.meta.description && (
-				<p class={`mt-1 ${text.helper}`}>{props.field.meta.description}</p>
-			)}
-		</div>
+		<Textarea
+			label={props.field.label}
+			rows={4}
+			value={props.value ?? ""}
+			onInput={(e) => props.onChange(e.currentTarget.value)}
+			placeholder={props.field.meta.placeholder}
+			disabled={props.disabled}
+			helperText={props.field.meta.description}
+		/>
 	);
 };

--- a/frontend/src/lib/widget-registry.tsx
+++ b/frontend/src/lib/widget-registry.tsx
@@ -22,6 +22,8 @@ import {
 	type JSX,
 } from "solid-js";
 import { z } from "zod";
+import Button from "~/components/ui/Button";
+import { Select } from "~/components/ui/Input";
 import AlertboxWidget from "~/components/widgets/AlertboxWidget";
 import ChatWidget from "~/components/widgets/ChatWidget";
 import DonationGoalWidget from "~/components/widgets/DonationGoalWidget";
@@ -41,7 +43,7 @@ import {
 	type ViewerData,
 } from "~/lib/fake/viewer-count";
 import type { FormMeta } from "~/lib/schema-form";
-import { button, input, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
 
 // =============================================================================
 // Widget Definition Type
@@ -511,12 +513,13 @@ function AlertboxPreviewWrapper(props: {
 
 	return (
 		<div>
-			<button
+			<Button
 				type="button"
-				class={`${button.secondary} mb-4`}
+				variant="secondary"
+				class="mb-4"
 				onClick={cycleDemoEvent}>
 				Show Next Alert Type
-			</button>
+			</Button>
 			<div class="rounded-lg bg-gray-900 p-8" style={{ height: "400px" }}>
 				<AlertboxWidget
 					config={props.config}
@@ -778,13 +781,14 @@ function GiveawayPreviewWrapper(props: {
 	return (
 		<div>
 			<div class="mb-4">
-				<select
-					class={input.select}
+				<Select
 					value={demoMode()}
-					onChange={(e) => setDemoMode(e.target.value as "active" | "winner")}>
+					onChange={(e) =>
+						setDemoMode(e.currentTarget.value as "active" | "winner")
+					}>
 					<option value="active">Active Giveaway</option>
 					<option value="winner">Winner Announcement</option>
-				</select>
+				</Select>
 			</div>
 			<div class="rounded-lg bg-gray-900 p-8">
 				<GiveawayWidget
@@ -839,16 +843,15 @@ function PollPreviewWrapper(props: {
 	return (
 		<div>
 			<div class="mb-4">
-				<label class="mb-2 block">
-					<span class={text.label}>Preview Mode</span>
-					<select
-						class={`${input.select} mt-1`}
-						value={demoMode()}
-						onChange={(e) => setDemoMode(e.target.value as "active" | "ended")}>
-						<option value="active">Active Poll</option>
-						<option value="ended">Ended Poll (Results)</option>
-					</select>
-				</label>
+				<Select
+					label="Preview Mode"
+					value={demoMode()}
+					onChange={(e) =>
+						setDemoMode(e.currentTarget.value as "active" | "ended")
+					}>
+					<option value="active">Active Poll</option>
+					<option value="ended">Ended Poll (Results)</option>
+				</Select>
 			</div>
 			<div class="rounded-lg bg-gray-900 p-8">
 				<PollWidget

--- a/frontend/src/routes/dashboard/admin/notifications.tsx
+++ b/frontend/src/routes/dashboard/admin/notifications.tsx
@@ -1,10 +1,14 @@
 import { Title } from "@solidjs/meta";
 import { useNavigate } from "@solidjs/router";
 import { createEffect, createSignal, For, Show } from "solid-js";
+import Badge from "~/components/ui/Badge";
+import Button from "~/components/ui/Button";
+import Card from "~/components/ui/Card";
+import Input, { Select, Textarea } from "~/components/ui/Input";
 import { useCurrentUser } from "~/lib/auth";
 import { type Notification, useGlobalNotifications } from "~/lib/useElectric";
 import { createNotification, deleteNotification } from "~/sdk/ash_rpc";
-import { badge, button, card, input, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
 
 export default function AdminNotifications() {
 	const navigate = useNavigate();
@@ -223,7 +227,7 @@ export default function AdminNotifications() {
 							</div>
 						</Show>
 
-						<div class={card.base}>
+						<Card>
 							<div class="flex items-center justify-between border-gray-200 border-b px-6 py-4">
 								<div>
 									<h3 class={text.h3}>Notifications</h3>
@@ -231,12 +235,7 @@ export default function AdminNotifications() {
 										Create and manage system notifications
 									</p>
 								</div>
-								<button
-									type="button"
-									onClick={openCreateModal}
-									class={button.primary}>
-									Create Notification
-								</button>
+								<Button onClick={openCreateModal}>Create Notification</Button>
 							</div>
 
 							<div class="overflow-x-auto">
@@ -269,8 +268,8 @@ export default function AdminNotifications() {
 													<td class="whitespace-nowrap px-6 py-4">
 														<Show
 															when={notification.user_id}
-															fallback={<span class={badge.info}>Global</span>}>
-															<span class={badge.warning}>User-specific</span>
+															fallback={<Badge variant="info">Global</Badge>}>
+															<Badge variant="warning">User-specific</Badge>
 														</Show>
 													</td>
 													<td class="whitespace-nowrap px-6 py-4 text-gray-500 text-sm">
@@ -310,16 +309,13 @@ export default function AdminNotifications() {
 										<p class="mt-4 text-gray-500 text-sm">
 											No notifications yet
 										</p>
-										<button
-											type="button"
-											onClick={openCreateModal}
-											class={`${button.primary} mt-4`}>
+										<Button onClick={openCreateModal} class="mt-4">
 											Create your first notification
-										</button>
+										</Button>
 									</div>
 								</Show>
 							</div>
-						</div>
+						</Card>
 					</div>
 
 					{/* Create Modal */}
@@ -354,17 +350,16 @@ export default function AdminNotifications() {
 									<div>
 										<label class="mb-2 block font-medium text-gray-700 text-sm">
 											Notification Type
-											<select
+											<Select
 												value={notificationType()}
 												onInput={(e) =>
 													setNotificationType(
 														e.currentTarget.value as "global" | "user",
 													)
-												}
-												class={input.select}>
+												}>
 												<option value="global">Global (All Users)</option>
 												<option value="user">User-specific</option>
-											</select>
+											</Select>
 										</label>
 										<p class={text.helper}>
 											{notificationType() === "global"
@@ -377,13 +372,12 @@ export default function AdminNotifications() {
 										<div>
 											<label class="mb-2 block font-medium text-gray-700 text-sm">
 												User ID <span class="text-red-500">*</span>
-												<input
+												<Input
 													type="text"
 													value={targetUserId()}
 													onInput={(e) =>
 														setTargetUserId(e.currentTarget.value)
 													}
-													class={input.text}
 													placeholder="Enter user UUID"
 												/>
 											</label>
@@ -393,13 +387,12 @@ export default function AdminNotifications() {
 									<div>
 										<label class="mb-2 block font-medium text-gray-700 text-sm">
 											Content <span class="text-red-500">*</span>
-											<textarea
+											<Textarea
 												value={notificationContent()}
 												onInput={(e) =>
 													setNotificationContent(e.currentTarget.value)
 												}
 												rows={4}
-												class={input.textarea}
 												placeholder="Enter notification message..."
 											/>
 										</label>
@@ -407,21 +400,16 @@ export default function AdminNotifications() {
 								</div>
 
 								<div class="flex justify-end space-x-3 rounded-b-lg bg-gray-50 px-6 py-4">
-									<button
-										type="button"
-										onClick={closeCreateModal}
-										class={button.secondary}>
+									<Button variant="secondary" onClick={closeCreateModal}>
 										Cancel
-									</button>
-									<button
-										type="button"
+									</Button>
+									<Button
 										onClick={handleCreate}
-										disabled={creating() || !notificationContent().trim()}
-										class={button.primary}>
+										disabled={creating() || !notificationContent().trim()}>
 										<Show when={creating()} fallback="Create Notification">
 											Creating...
 										</Show>
-									</button>
+									</Button>
 								</div>
 							</div>
 						</div>
@@ -468,21 +456,17 @@ export default function AdminNotifications() {
 								</div>
 
 								<div class="flex justify-end space-x-3 rounded-b-lg bg-gray-50 px-6 py-4">
-									<button
-										type="button"
-										onClick={closeDeleteConfirm}
-										class={button.secondary}>
+									<Button variant="secondary" onClick={closeDeleteConfirm}>
 										Cancel
-									</button>
-									<button
-										type="button"
+									</Button>
+									<Button
+										variant="danger"
 										onClick={handleDelete}
-										disabled={deleting()}
-										class={button.danger}>
+										disabled={deleting()}>
 										<Show when={deleting()} fallback="Delete">
 											Deleting...
 										</Show>
-									</button>
+									</Button>
 								</div>
 							</div>
 						</div>

--- a/frontend/src/routes/dashboard/admin/users.tsx
+++ b/frontend/src/routes/dashboard/admin/users.tsx
@@ -2,12 +2,16 @@ import { Title } from "@solidjs/meta";
 import { useNavigate } from "@solidjs/router";
 import { useLiveQuery } from "@tanstack/solid-db";
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import Badge from "~/components/ui/Badge";
+import Button from "~/components/ui/Button";
+import Card from "~/components/ui/Card";
+import Input, { Select, Textarea } from "~/components/ui/Input";
 import { Alert } from "~/components/ui";
 import { useCurrentUser } from "~/lib/auth";
 import { type AdminUser, getAdminUsersCollection } from "~/lib/electric";
 import { usePresence } from "~/lib/socket";
 import { grantProAccess, revokeProAccess } from "~/sdk/ash_rpc";
-import { badge, button, card, input, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
 
 export default function AdminUsers() {
 	const navigate = useNavigate();
@@ -180,7 +184,7 @@ export default function AdminUsers() {
 							</Alert>
 						</Show>
 
-						<div class={card.base}>
+						<Card>
 							<div class="flex items-center justify-between border-gray-200 border-b px-6 py-4">
 								<div>
 									<h3 class={text.h3}>All Users</h3>
@@ -259,7 +263,7 @@ export default function AdminUsers() {
 																		{user.name}
 																	</span>
 																	<Show when={currentUser()?.id === user.id}>
-																		<span class={badge.info}>Current User</span>
+																		<Badge variant="info">Current User</Badge>
 																	</Show>
 																</div>
 															</div>
@@ -272,9 +276,9 @@ export default function AdminUsers() {
 														<Show
 															when={user.confirmed_at}
 															fallback={
-																<span class={badge.warning}>Pending</span>
+																<Badge variant="warning">Pending</Badge>
 															}>
-															<span class={badge.success}>Confirmed</span>
+															<Badge variant="success">Confirmed</Badge>
 														</Show>
 													</td>
 													<td class="whitespace-nowrap px-6 py-4 text-gray-500 text-sm">
@@ -315,7 +319,7 @@ export default function AdminUsers() {
 									</div>
 								</Show>
 							</div>
-						</div>
+						</Card>
 					</div>
 
 					<Show when={showGrantModal()}>
@@ -356,27 +360,28 @@ export default function AdminUsers() {
 									<div>
 										<label class="mb-2 block font-medium text-gray-700 text-sm">
 											Duration
-											<select
+											<Select
 												value={grantDuration()}
-												onInput={(e) => setGrantDuration(e.currentTarget.value)}
-												class={input.select}>
+												onInput={(e) =>
+													setGrantDuration(e.currentTarget.value)
+												}>
 												<option value="7">7 days</option>
 												<option value="30">30 days</option>
 												<option value="90">90 days (3 months)</option>
 												<option value="180">180 days (6 months)</option>
 												<option value="365">365 days (1 year)</option>
-											</select>
+											</Select>
 										</label>
 									</div>
 
 									<div>
 										<label class="block font-medium text-gray-700 text-sm">
 											Reason <span class="text-red-500">*</span>
-											<textarea
+											<Textarea
 												value={grantReason()}
 												onInput={(e) => setGrantReason(e.currentTarget.value)}
 												rows={3}
-												class={`mt-2 ${input.textarea}`}
+												class="mt-2"
 												placeholder="e.g., Beta tester, Partner program, Promotional access..."
 											/>
 										</label>
@@ -387,21 +392,16 @@ export default function AdminUsers() {
 								</div>
 
 								<div class="flex justify-end space-x-3 rounded-b-lg bg-gray-50 px-6 py-4">
-									<button
-										type="button"
-										onClick={closeGrantModal}
-										class={button.secondary}>
+									<Button variant="secondary" onClick={closeGrantModal}>
 										Cancel
-									</button>
-									<button
-										type="button"
+									</Button>
+									<Button
 										onClick={handleGrantPro}
-										disabled={grantingPro() || !grantReason().trim()}
-										class={button.primary}>
+										disabled={grantingPro() || !grantReason().trim()}>
 										<Show when={grantingPro()} fallback="Grant PRO Access">
 											Granting...
 										</Show>
-									</button>
+									</Button>
 								</div>
 							</div>
 						</div>
@@ -443,21 +443,17 @@ export default function AdminUsers() {
 								</div>
 
 								<div class="flex justify-end space-x-3 rounded-b-lg bg-gray-50 px-6 py-4">
-									<button
-										type="button"
-										onClick={closeRevokeConfirm}
-										class={button.secondary}>
+									<Button variant="secondary" onClick={closeRevokeConfirm}>
 										Cancel
-									</button>
-									<button
-										type="button"
+									</Button>
+									<Button
+										variant="danger"
 										onClick={handleRevokePro}
-										disabled={revokingPro()}
-										class={button.danger}>
+										disabled={revokingPro()}>
 										<Show when={revokingPro()} fallback="Revoke PRO">
 											Revoking...
 										</Show>
-									</button>
+									</Button>
 								</div>
 							</div>
 						</div>

--- a/frontend/src/routes/dashboard/chat-history.tsx
+++ b/frontend/src/routes/dashboard/chat-history.tsx
@@ -8,10 +8,13 @@ import {
 	Show,
 	Suspense,
 } from "solid-js";
+import Badge from "~/components/ui/Badge";
+import Card from "~/components/ui/Card";
+import Input, { Select } from "~/components/ui/Input";
 import { Skeleton, SkeletonListItem } from "~/components/ui";
 import { getLoginUrl, useCurrentUser } from "~/lib/auth";
 import { getChatHistory } from "~/sdk/ash_rpc";
-import { badge, card, input, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
 
 type Platform = "twitch" | "youtube" | "facebook" | "kick" | "";
 type DateRange = "7days" | "30days" | "3months" | "";
@@ -21,7 +24,7 @@ function ChatHistorySkeleton() {
 	return (
 		<div class="mx-auto max-w-6xl space-y-6">
 			{/* Filters skeleton */}
-			<div class={card.default}>
+			<Card>
 				<Skeleton class="mb-4 h-6 w-20" />
 				<div class="mb-4 grid grid-cols-1 gap-4 md:grid-cols-3">
 					<For each={[1, 2, 3]}>
@@ -33,10 +36,10 @@ function ChatHistorySkeleton() {
 						)}
 					</For>
 				</div>
-			</div>
+			</Card>
 
 			{/* Messages skeleton */}
-			<div class={card.default}>
+			<Card>
 				<Skeleton class="mb-4 h-6 w-24" />
 				<div class="space-y-3">
 					<For each={[1, 2, 3, 4, 5, 6, 7, 8]}>
@@ -53,7 +56,7 @@ function ChatHistorySkeleton() {
 						)}
 					</For>
 				</div>
-			</div>
+			</Card>
 		</div>
 	);
 }
@@ -203,22 +206,25 @@ function ChatHistoryContent(props: {
 		return date.toLocaleString();
 	};
 
-	const getPlatformBadgeColor = (platformName: string) => {
-		const colors = {
-			twitch: badge.info,
-			youtube: badge.error,
-			facebook: badge.info,
-			kick: badge.success,
+	const getPlatformBadgeVariant = (
+		platformName: string,
+	): "info" | "error" | "success" | "warning" | "neutral" => {
+		const variants: Record<
+			string,
+			"info" | "error" | "success" | "warning" | "neutral"
+		> = {
+			twitch: "info",
+			youtube: "error",
+			facebook: "info",
+			kick: "success",
 		};
-		return (
-			colors[platformName.toLowerCase() as keyof typeof colors] || badge.neutral
-		);
+		return variants[platformName.toLowerCase()] || "neutral";
 	};
 
 	return (
 		<div class="mx-auto max-w-6xl space-y-6">
 			{/* Filters Section */}
-			<div class={card.default}>
+			<Card>
 				<h3 class={`${text.h3} mb-4`}>Filters</h3>
 
 				<div class="mb-4 grid grid-cols-1 gap-4 md:grid-cols-3">
@@ -226,8 +232,8 @@ function ChatHistoryContent(props: {
 					<div>
 						<label class="block font-medium text-gray-700 text-sm">
 							Platform
-							<select
-								class={`mt-2 ${input.select}`}
+							<Select
+								class="mt-2"
 								value={props.platform()}
 								onChange={(e) => {
 									props.setPlatform(e.currentTarget.value as Platform);
@@ -237,7 +243,7 @@ function ChatHistoryContent(props: {
 								<option value="youtube">YouTube</option>
 								<option value="facebook">Facebook</option>
 								<option value="kick">Kick</option>
-							</select>
+							</Select>
 						</label>
 					</div>
 
@@ -245,8 +251,8 @@ function ChatHistoryContent(props: {
 					<div>
 						<label class="block font-medium text-gray-700 text-sm">
 							Date Range
-							<select
-								class={`mt-2 ${input.select}`}
+							<Select
+								class="mt-2"
 								value={props.dateRange()}
 								onChange={(e) => {
 									props.setDateRange(e.currentTarget.value as DateRange);
@@ -255,7 +261,7 @@ function ChatHistoryContent(props: {
 								<option value="7days">Last 7 Days</option>
 								<option value="30days">Last 30 Days</option>
 								<option value="3months">Last 3 Months</option>
-							</select>
+							</Select>
 						</label>
 					</div>
 
@@ -264,9 +270,9 @@ function ChatHistoryContent(props: {
 						<label class="block font-medium text-gray-700 text-sm">
 							Search
 							<form onSubmit={props.handleSearch}>
-								<input
+								<Input
 									type="text"
-									class={`mt-2 ${input.text}`}
+									class="mt-2"
 									placeholder="Search messages..."
 									value={props.searchInput()}
 									onInput={(e) => props.setSearchInput(e.currentTarget.value)}
@@ -281,17 +287,17 @@ function ChatHistoryContent(props: {
 					<div class="flex items-center gap-2 text-gray-600 text-sm">
 						<span class="font-medium">Active filters:</span>
 						<Show when={props.platform()}>
-							<span class={badge.info}>{props.platform()}</span>
+							<Badge variant="info">{props.platform()}</Badge>
 						</Show>
 						<Show when={props.dateRange()}>
-							<span class={badge.info}>
+							<Badge variant="info">
 								{props.dateRange() === "7days" && "Last 7 Days"}
 								{props.dateRange() === "30days" && "Last 30 Days"}
 								{props.dateRange() === "3months" && "Last 3 Months"}
-							</span>
+							</Badge>
 						</Show>
 						<Show when={props.search()}>
-							<span class={badge.info}>"{props.search()}"</span>
+							<Badge variant="info">"{props.search()}"</Badge>
 						</Show>
 						<button
 							type="button"
@@ -305,10 +311,10 @@ function ChatHistoryContent(props: {
 						</button>
 					</div>
 				</Show>
-			</div>
+			</Card>
 
 			{/* Messages List */}
-			<div class={card.default}>
+			<Card>
 				<h3 class={`${text.h3} mb-4`}>Messages</h3>
 
 				<Show
@@ -359,16 +365,14 @@ function ChatHistoryContent(props: {
 														{msg.senderUsername}
 													</A>
 												</Show>
-												<span class={getPlatformBadgeColor(msg.platform)}>
+												<Badge variant={getPlatformBadgeVariant(msg.platform)}>
 													{msg.platform}
-												</span>
+												</Badge>
 												<Show when={msg.senderIsModerator}>
-													<span class={badge.success}>MOD</span>
+													<Badge variant="success">MOD</Badge>
 												</Show>
 												<Show when={msg.senderIsPatreon}>
-													<span class="inline-flex items-center rounded-full bg-pink-100 px-2.5 py-0.5 font-medium text-pink-800 text-xs">
-														Patron
-													</span>
+													<Badge variant="warning">Patron</Badge>
 												</Show>
 												<span class={text.muted}>
 													{formatDate(msg.insertedAt as string)}
@@ -384,7 +388,7 @@ function ChatHistoryContent(props: {
 						</For>
 					</div>
 				</Show>
-			</div>
+			</Card>
 		</div>
 	);
 }

--- a/frontend/src/routes/dashboard/index.tsx
+++ b/frontend/src/routes/dashboard/index.tsx
@@ -20,7 +20,10 @@ import {
 	useUserPreferencesForUser,
 	useUserStreamEvents,
 } from "~/lib/useElectric";
-import { badge, card, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
+import Card from "~/components/ui/Card";
+import Badge from "~/components/ui/Badge";
+import Button from "~/components/ui/Button";
 
 function getEventIcon(type: string) {
 	switch (type) {
@@ -107,14 +110,16 @@ function getEventIcon(type: string) {
 	}
 }
 
-function getStreamStatusBadge(status: string) {
+function getStreamStatusBadgeVariant(
+	status: string,
+): "success" | "neutral" | "warning" {
 	switch (status) {
 		case "live":
-			return badge.success;
+			return "success";
 		case "ended":
-			return badge.neutral;
+			return "neutral";
 		default:
-			return badge.warning;
+			return "warning";
 	}
 }
 
@@ -124,9 +129,9 @@ function QuickStatsSkeleton() {
 		<div class="grid grid-cols-2 gap-4 md:grid-cols-4">
 			<For each={[1, 2, 3, 4]}>
 				{() => (
-					<div class={`${card.base} p-4`}>
+					<Card padding="sm">
 						<SkeletonStat showIcon />
-					</div>
+					</Card>
 				)}
 			</For>
 		</div>
@@ -136,7 +141,7 @@ function QuickStatsSkeleton() {
 // Skeleton for Recent Chat section
 function RecentChatSkeleton() {
 	return (
-		<div class={card.base}>
+		<Card padding="none">
 			<div class="flex items-center justify-between border-gray-200 border-b px-6 py-4">
 				<Skeleton class="h-5 w-28" />
 				<Skeleton class="h-4 w-16" />
@@ -150,14 +155,14 @@ function RecentChatSkeleton() {
 					)}
 				</For>
 			</div>
-		</div>
+		</Card>
 	);
 }
 
 // Skeleton for Recent Events section
 function RecentEventsSkeleton() {
 	return (
-		<div class={card.base}>
+		<Card padding="none">
 			<div class="flex items-center justify-between border-gray-200 border-b px-6 py-4">
 				<Skeleton class="h-5 w-32" />
 				<Skeleton class="h-4 w-16" />
@@ -171,14 +176,14 @@ function RecentEventsSkeleton() {
 					)}
 				</For>
 			</div>
-		</div>
+		</Card>
 	);
 }
 
 // Skeleton for Activity Feed
 function ActivityFeedSkeleton() {
 	return (
-		<div class={card.base}>
+		<Card padding="none">
 			<div class="border-gray-100 border-b px-4 py-3">
 				<div class="mb-3 flex items-center justify-between">
 					<Skeleton class="h-5 w-28" />
@@ -206,14 +211,14 @@ function ActivityFeedSkeleton() {
 					)}
 				</For>
 			</div>
-		</div>
+		</Card>
 	);
 }
 
 // Skeleton for Recent Streams section
 function RecentStreamsSkeleton() {
 	return (
-		<div class={card.base}>
+		<Card padding="none">
 			<div class="flex items-center justify-between border-gray-200 border-b px-6 py-4">
 				<Skeleton class="h-5 w-32" />
 				<Skeleton class="h-4 w-16" />
@@ -221,7 +226,7 @@ function RecentStreamsSkeleton() {
 			<div class="divide-y divide-gray-100">
 				<For each={[1, 2, 3]}>{() => <SkeletonStreamCard />}</For>
 			</div>
-		</div>
+		</Card>
 	);
 }
 
@@ -289,7 +294,7 @@ function StreamHealthMonitor() {
 	};
 
 	return (
-		<div class={`${card.base} p-4`} data-testid="stream-health-monitor">
+		<Card padding="sm" data-testid="stream-health-monitor">
 			<div class="mb-4 flex items-center justify-between">
 				<h3 class="flex items-center gap-2 font-semibold text-gray-900">
 					<svg
@@ -329,7 +334,7 @@ function StreamHealthMonitor() {
 					<p class="text-gray-500 text-xs">{t("dashboard.uptime")}</p>
 				</div>
 			</div>
-		</div>
+		</Card>
 	);
 }
 
@@ -499,7 +504,7 @@ function ViewerEngagementScore(props: {
 	};
 
 	return (
-		<div class={`${card.base} p-4`} data-testid="engagement-score">
+		<Card padding="sm" data-testid="engagement-score">
 			<div class="mb-3 flex items-center justify-between">
 				<h3 class="flex items-center gap-2 font-semibold text-gray-900">
 					<svg
@@ -545,7 +550,7 @@ function ViewerEngagementScore(props: {
 					</div>
 				</div>
 			</div>
-		</div>
+		</Card>
 	);
 }
 
@@ -614,7 +619,7 @@ function StreamGoalsTracker(props: {
 	};
 
 	return (
-		<div class={card.base} data-testid="stream-goals">
+		<Card padding="none" data-testid="stream-goals">
 			<div class="border-gray-100 border-b px-4 py-3">
 				<h3 class="flex items-center gap-2 font-semibold text-gray-900">
 					<svg
@@ -679,7 +684,7 @@ function StreamGoalsTracker(props: {
 					}}
 				</For>
 			</div>
-		</div>
+		</Card>
 	);
 }
 
@@ -713,7 +718,7 @@ function ActivityFeed(props: {
 	);
 
 	return (
-		<div class={card.base} data-testid="activity-feed">
+		<Card padding="none" data-testid="activity-feed">
 			<div class="border-gray-100 border-b px-4 py-3">
 				<div class="mb-3 flex items-center justify-between">
 					<h3 class="flex items-center gap-2 font-semibold text-gray-900">
@@ -809,7 +814,7 @@ function ActivityFeed(props: {
 					</div>
 				</Show>
 			</div>
-		</div>
+		</Card>
 	);
 }
 
@@ -904,7 +909,7 @@ export default function Dashboard() {
 
 						{/* Quick Stats */}
 						<div class="grid grid-cols-2 gap-4 md:grid-cols-4">
-							<div class={`${card.base} p-4`}>
+							<Card padding="sm" class="p-4">
 								<div class="flex items-center gap-3">
 									<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100">
 										<svg
@@ -930,9 +935,9 @@ export default function Dashboard() {
 										</p>
 									</div>
 								</div>
-							</div>
+							</Card>
 
-							<div class={`${card.base} p-4`}>
+							<Card padding="sm" class="p-4">
 								<div class="flex items-center gap-3">
 									<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-100">
 										<svg
@@ -964,9 +969,9 @@ export default function Dashboard() {
 										</p>
 									</div>
 								</div>
-							</div>
+							</Card>
 
-							<div class={`${card.base} p-4`}>
+							<Card padding="sm" class="p-4">
 								<div class="flex items-center gap-3">
 									<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-pink-100">
 										<svg
@@ -992,9 +997,9 @@ export default function Dashboard() {
 										</p>
 									</div>
 								</div>
-							</div>
+							</Card>
 
-							<div class={`${card.base} p-4`}>
+							<Card padding="sm" class="p-4">
 								<div class="flex items-center gap-3">
 									<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-green-100">
 										<svg
@@ -1020,7 +1025,7 @@ export default function Dashboard() {
 										</p>
 									</div>
 								</div>
-							</div>
+							</Card>
 						</div>
 
 						{/* New Features Row: Stream Health, Engagement Score, Goals */}
@@ -1042,7 +1047,7 @@ export default function Dashboard() {
 						{/* Main Content Grid */}
 						<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
 							{/* Recent Chat Messages */}
-							<div class={card.base}>
+							<Card padding="none">
 								<div class="flex items-center justify-between border-gray-200 border-b px-6 py-4">
 									<h3 class={text.h3}>{t("dashboard.recentChat")}</h3>
 									<A
@@ -1092,7 +1097,7 @@ export default function Dashboard() {
 																	{msg.sender_username}
 																</span>
 																<Show when={msg.sender_is_moderator}>
-																	<span class={badge.info}>Mod</span>
+																	<Badge variant="info">Mod</Badge>
 																</Show>
 																<span class="text-gray-400 text-xs">
 																	{formatTimeAgo(msg.inserted_at)}
@@ -1108,10 +1113,10 @@ export default function Dashboard() {
 										</For>
 									</Show>
 								</div>
-							</div>
+							</Card>
 
 							{/* Recent Events */}
-							<div class={card.base}>
+							<Card padding="none">
 								<div class="flex items-center justify-between border-gray-200 border-b px-6 py-4">
 									<h3 class={text.h3}>{t("dashboard.recentEvents")}</h3>
 									<A
@@ -1185,14 +1190,14 @@ export default function Dashboard() {
 										</For>
 									</Show>
 								</div>
-							</div>
+							</Card>
 						</div>
 
 						{/* Activity Feed with Filters */}
 						<ActivityFeed events={allEvents()} />
 
 						{/* Recent Streams */}
-						<div class={card.base}>
+						<Card padding="none">
 							<div class="flex items-center justify-between border-gray-200 border-b px-6 py-4">
 								<h3 class={text.h3}>{t("dashboard.recentStreams")}</h3>
 								<A
@@ -1262,16 +1267,19 @@ export default function Dashboard() {
 															</p>
 														</div>
 													</div>
-													<span class={getStreamStatusBadge(stream.status)}>
+													<Badge
+														variant={getStreamStatusBadgeVariant(
+															stream.status,
+														)}>
 														{stream.status}
-													</span>
+													</Badge>
 												</div>
 											</A>
 										)}
 									</For>
 								</div>
 							</Show>
-						</div>
+						</Card>
 
 						{/* Quick Actions */}
 						<div class="grid grid-cols-1 gap-4 md:grid-cols-3">

--- a/frontend/src/routes/dashboard/smart-canvas/index.tsx
+++ b/frontend/src/routes/dashboard/smart-canvas/index.tsx
@@ -1,8 +1,10 @@
 import { Title } from "@solidjs/meta";
 import { createEffect, createSignal, For, onMount, Show } from "solid-js";
+import Button from "~/components/ui/Button";
+import Card from "~/components/ui/Card";
 import { useCurrentUser } from "~/lib/auth";
 import { getSmartCanvasLayout, saveSmartCanvasLayout } from "~/sdk/ash_rpc";
-import { button, card, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
 
 interface CanvasWidget {
 	id: string;
@@ -520,13 +522,13 @@ export default function SmartCanvas() {
 			<Title>Smart Canvas - Streampai</Title>
 			<Show when={user()}>
 				<div class="space-y-6">
-					<div class={card.default}>
+					<Card>
 						<h1 class={text.h1}>Smart Canvas</h1>
 						<p class={`${text.muted} mt-2`}>
 							Compose your stream overlay with interactive widgets. Click
 							widgets from the palette to add them to the canvas.
 						</p>
-					</div>
+					</Card>
 
 					<div class="rounded-2xl border border-blue-200 bg-blue-50 p-4">
 						<div class="flex items-start gap-3">
@@ -546,54 +548,43 @@ export default function SmartCanvas() {
 										value={obsUrl()}
 										class="flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 font-mono text-sm"
 									/>
-									<button
-										type="button"
-										class={button.primary}
+									<Button
 										onClick={() => {
 											navigator.clipboard.writeText(obsUrl());
 										}}>
 										Copy
-									</button>
+									</Button>
 								</div>
 							</div>
 						</div>
 					</div>
 
-					<div class={card.default}>
+					<Card>
 						<div class="flex items-center justify-between">
 							<div class="flex gap-2">
-								<button
-									type="button"
-									class={
-										layoutSaved()
-											? "rounded-lg bg-green-600 px-4 py-2 text-white"
-											: button.primary
-									}
+								<Button
+									variant={layoutSaved() ? "success" : "primary"}
 									onClick={saveLayout}>
-									{layoutSaved() ? "✓ Layout Saved" : "Save Layout"}
-								</button>
-								<button
-									type="button"
-									class={button.secondary}
-									onClick={clearWidgets}>
+									{layoutSaved() ? "Layout Saved" : "Save Layout"}
+								</Button>
+								<Button variant="secondary" onClick={clearWidgets}>
 									Clear All
-								</button>
-								<button
-									type="button"
-									class={button.ghost}
+								</Button>
+								<Button
+									variant="ghost"
 									onClick={() => setCanvasMaximized(!canvasMaximized())}>
 									{canvasMaximized() ? "Exit Fullscreen" : "Fullscreen"}
-								</button>
+								</Button>
 							</div>
 							<div class="text-gray-600 text-sm">
 								Widgets: {widgets().length}
 							</div>
 						</div>
-					</div>
+					</Card>
 
 					<div class="grid grid-cols-1 gap-6 lg:grid-cols-4">
 						<div class="lg:col-span-1">
-							<div class={`${card.default} max-h-[700px] overflow-y-auto`}>
+							<Card class="max-h-[700px] overflow-y-auto">
 								<h3 class={`${text.h3} mb-4`}>Widget Palette</h3>
 								<p class="mb-4 text-gray-600 text-sm">
 									Click a widget to add it to the canvas
@@ -603,12 +594,12 @@ export default function SmartCanvas() {
 										{(widgetDef) => <PaletteWidgetItem widgetDef={widgetDef} />}
 									</For>
 								</div>
-							</div>
+							</Card>
 						</div>
 
 						<div class="lg:col-span-3">
-							<div
-								class={`${card.default} bg-gray-900 p-4`}
+							<Card
+								class="bg-gray-900 p-4"
 								classList={{
 									"!fixed !inset-0 !z-50 !m-0 !rounded-none": canvasMaximized(),
 								}}>
@@ -682,7 +673,7 @@ export default function SmartCanvas() {
 										</div>
 									</div>
 								</div>
-							</div>
+							</Card>
 						</div>
 					</div>
 				</div>

--- a/frontend/src/routes/dashboard/stream-history/[id].tsx
+++ b/frontend/src/routes/dashboard/stream-history/[id].tsx
@@ -9,6 +9,7 @@ import {
 	Show,
 	Suspense,
 } from "solid-js";
+import Badge from "~/components/ui/Badge";
 import {
 	Card,
 	Skeleton,
@@ -131,14 +132,19 @@ const formatTimelineTime = (stream: Livestream, position: number) => {
 	return formatDuration(seconds);
 };
 
-const platformBadgeColor = (platform: string) => {
-	const colors: Record<string, string> = {
-		twitch: "bg-purple-100 text-purple-800",
-		youtube: "bg-red-100 text-red-800",
-		facebook: "bg-blue-100 text-blue-800",
-		kick: "bg-green-100 text-green-800",
+const getPlatformBadgeVariant = (
+	platform: string,
+): "info" | "error" | "success" | "warning" | "neutral" => {
+	const variants: Record<
+		string,
+		"info" | "error" | "success" | "warning" | "neutral"
+	> = {
+		twitch: "info",
+		youtube: "error",
+		facebook: "info",
+		kick: "success",
 	};
-	return colors[platform.toLowerCase()] || "bg-gray-100 text-gray-800";
+	return variants[platform.toLowerCase()] || "neutral";
 };
 
 const platformName = (platform: string) => {
@@ -547,12 +553,9 @@ function StreamDetailContent(props: { streamId: string }) {
 						<div class="flex flex-wrap items-center gap-y-2 space-x-2 text-gray-600 text-sm">
 							<For each={stream()?.platforms || []}>
 								{(platform) => (
-									<span
-										class={`inline-flex items-center rounded px-2 py-1 font-medium text-xs ${platformBadgeColor(
-											platform,
-										)}`}>
+									<Badge variant={getPlatformBadgeVariant(platform)}>
 										{platformName(platform)}
-									</span>
+									</Badge>
 								)}
 							</For>
 							<span>{formatDate(stream()?.startedAt || "")}</span>
@@ -888,22 +891,18 @@ function StreamDetailContent(props: { streamId: string }) {
 															{message.senderUsername}
 														</span>
 														<Show when={message.platform}>
-															<span
-																class={`inline-flex items-center rounded px-1 py-0.5 font-medium text-xs ${platformBadgeColor(
+															<Badge
+																variant={getPlatformBadgeVariant(
 																	message.platform ?? "",
-																)}`}>
+																)}>
 																{platformInitial(message.platform ?? "")}
-															</span>
+															</Badge>
 														</Show>
 														<Show when={message.senderIsModerator}>
-															<span class="inline-flex items-center rounded bg-green-100 px-1 py-0.5 font-medium text-green-800 text-xs">
-																MOD
-															</span>
+															<Badge variant="success">MOD</Badge>
 														</Show>
 														<Show when={message.senderIsPatreon}>
-															<span class="inline-flex items-center rounded bg-purple-100 px-1 py-0.5 font-medium text-purple-800 text-xs">
-																SUB
-															</span>
+															<Badge variant="info">SUB</Badge>
 														</Show>
 													</div>
 													<p class="mt-0.5 text-gray-600 text-xs">

--- a/frontend/src/routes/dashboard/stream.tsx
+++ b/frontend/src/routes/dashboard/stream.tsx
@@ -1,6 +1,8 @@
 import { Title } from "@solidjs/meta";
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import Badge from "~/components/ui/Badge";
 import Button from "~/components/ui/Button";
+import Card from "~/components/ui/Card";
 import { Skeleton } from "~/components/ui";
 import { getLoginUrl, useCurrentUser } from "~/lib/auth";
 import { apiRoutes } from "~/lib/constants";
@@ -10,7 +12,7 @@ import {
 	getStreamKey,
 	regenerateStreamKey,
 } from "~/sdk/ash_rpc";
-import { badge, button, card, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
 
 // Platform configuration
 const availablePlatforms = [
@@ -49,7 +51,7 @@ function StreamPageSkeleton() {
 	return (
 		<div class="mx-auto max-w-7xl space-y-6">
 			{/* Stream Status Card skeleton */}
-			<div class={card.default}>
+			<Card>
 				<div class="mb-6 flex items-center justify-between">
 					<div>
 						<Skeleton class="mb-2 h-8 w-40" />
@@ -75,10 +77,10 @@ function StreamPageSkeleton() {
 					<Skeleton class="h-10 w-24 rounded-lg" />
 					<Skeleton class="h-10 w-36 rounded-lg" />
 				</div>
-			</div>
+			</Card>
 
 			{/* Platform Connections skeleton */}
-			<div class={card.default}>
+			<Card>
 				<div class="mb-6">
 					<Skeleton class="mb-2 h-6 w-44" />
 					<Skeleton class="h-4 w-64" />
@@ -100,7 +102,7 @@ function StreamPageSkeleton() {
 						)}
 					</For>
 				</div>
-			</div>
+			</Card>
 		</div>
 	);
 }
@@ -318,7 +320,7 @@ export default function Stream() {
 					}>
 					<div class="mx-auto max-w-7xl space-y-6">
 						{/* Stream Status Card */}
-						<div class={card.default}>
+						<Card>
 							<div class="mb-6 flex items-center justify-between">
 								<div>
 									<h2 class={text.h2}>Stream Controls</h2>
@@ -327,13 +329,13 @@ export default function Stream() {
 								<Show
 									when={streamStatus() === "live"}
 									fallback={
-										<span class={badge.neutral}>
+										<Badge variant="neutral">
 											{streamStatus().toUpperCase()}
-										</span>
+										</Badge>
 									}>
-									<span class={badge.success}>
-										<span class="mr-2 animate-pulse">●</span> LIVE
-									</span>
+									<Badge variant="success">
+										<span class="mr-2 animate-pulse">*</span> LIVE
+									</Badge>
 								</Show>
 							</div>
 
@@ -380,30 +382,27 @@ export default function Stream() {
 								<Show
 									when={streamStatus() === "offline"}
 									fallback={
-										<button
-											type="button"
-											class={button.danger}
+										<Button
+											variant="danger"
 											onClick={handleStopStream}
 											disabled={streamStatus() === "stopping"}>
 											{streamStatus() === "stopping"
 												? "Stopping..."
 												: "Stop Stream"}
-										</button>
+										</Button>
 									}>
-									<button
-										type="button"
-										class={button.success}
+									<Button
+										variant="success"
 										onClick={handleStartStream}
 										disabled={streamStatus() === "starting"}>
 										{streamStatus() === "starting" ? "Starting..." : "Go Live"}
-									</button>
+									</Button>
 								</Show>
-								<button
-									type="button"
-									class={button.secondary}
+								<Button
+									variant="secondary"
 									onClick={() => setShowStreamKey(!showStreamKey())}>
 									{showStreamKey() ? "Hide" : "Show"} Stream Key
-								</button>
+								</Button>
 							</div>
 
 							{/* Stream Key Display */}
@@ -423,15 +422,16 @@ export default function Stream() {
 											fallback={
 												<div class="text-center">
 													<p class="text-red-600 text-sm">{streamKeyError()}</p>
-													<button
-														type="button"
-														class={`${button.ghost} mt-2 text-sm`}
+													<Button
+														variant="ghost"
+														size="sm"
+														class="mt-2"
 														onClick={() => {
 															const currentUser = user();
 															if (currentUser) fetchStreamKey(currentUser.id);
 														}}>
 														Retry
-													</button>
+													</Button>
 												</div>
 											}>
 											<div class="mb-3 flex items-center justify-between">
@@ -439,21 +439,22 @@ export default function Stream() {
 													Stream Key
 												</span>
 												<div class="flex items-center space-x-2">
-													<button
-														type="button"
-														class={`${button.ghost} text-sm`}
+													<Button
+														variant="ghost"
+														size="sm"
 														onClick={handleCopyStreamKey}>
 														{copied() ? "Copied!" : "Copy Key"}
-													</button>
-													<button
-														type="button"
-														class={`${button.ghost} text-red-600 text-sm hover:bg-red-50`}
+													</Button>
+													<Button
+														variant="ghost"
+														size="sm"
+														class="text-red-600 hover:bg-red-50"
 														onClick={handleRegenerateStreamKey}
 														disabled={isRegenerating()}>
 														{isRegenerating()
 															? "Regenerating..."
 															: "Regenerate"}
-													</button>
+													</Button>
 												</div>
 											</div>
 
@@ -499,10 +500,10 @@ export default function Stream() {
 									</Show>
 								</div>
 							</Show>
-						</div>
+						</Card>
 
 						{/* Platform Connections */}
-						<div class={card.default}>
+						<Card>
 							<div class="mb-6">
 								<h3 class={text.h3}>Platform Connections</h3>
 								<p class={text.muted}>
@@ -616,11 +617,11 @@ export default function Stream() {
 									</For>
 								</div>
 							</Show>
-						</div>
+						</Card>
 
 						{/* Stream Statistics (Placeholder) */}
 						<Show when={streamStatus() === "live"}>
-							<div class={card.default}>
+							<Card>
 								<h3 class={`${text.h3} mb-4`}>Live Statistics</h3>
 								<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
 									<div class="rounded-lg bg-purple-50 p-4 text-center">
@@ -636,7 +637,7 @@ export default function Stream() {
 										<div class="text-gray-600 text-sm">Stream Duration</div>
 									</div>
 								</div>
-							</div>
+							</Card>
 						</Show>
 					</div>
 				</Show>

--- a/frontend/src/routes/dashboard/viewers/[id].tsx
+++ b/frontend/src/routes/dashboard/viewers/[id].tsx
@@ -1,9 +1,13 @@
 import { Title } from "@solidjs/meta";
 import { A, useNavigate, useParams } from "@solidjs/router";
 import { createSignal, For, onMount, Show } from "solid-js";
+import Badge from "~/components/ui/Badge";
+import Button from "~/components/ui/Button";
+import Card from "~/components/ui/Card";
 import { Skeleton, SkeletonListItem } from "~/components/ui";
 import { useCurrentUser } from "~/lib/auth";
 import { getViewerChat, getViewerEvents, listViewers } from "~/sdk/ash_rpc";
+import { text } from "~/styles/design-system";
 
 const viewerFields: (
 	| "viewerId"
@@ -104,14 +108,19 @@ interface StreamEvent {
 }
 
 // Helper functions
-const platformBadgeColor = (platform: string) => {
-	const colors: Record<string, string> = {
-		twitch: "bg-purple-100 text-purple-800",
-		youtube: "bg-red-100 text-red-800",
-		facebook: "bg-blue-100 text-blue-800",
-		kick: "bg-green-100 text-green-800",
+const getPlatformBadgeVariant = (
+	platform: string,
+): "info" | "error" | "success" | "warning" | "neutral" => {
+	const variants: Record<
+		string,
+		"info" | "error" | "success" | "warning" | "neutral"
+	> = {
+		twitch: "info",
+		youtube: "error",
+		facebook: "info",
+		kick: "success",
 	};
-	return colors[platform.toLowerCase()] || "bg-gray-100 text-gray-800";
+	return variants[platform.toLowerCase()] || "neutral";
 };
 
 const platformName = (platform: string) => {
@@ -412,33 +421,23 @@ export default function ViewerDetail() {
 						</div>
 						<div class="flex items-center gap-2">
 							<Show when={viewer()?.isVerified}>
-								<span class="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 font-medium text-blue-800 text-sm">
-									Verified
-								</span>
+								<Badge variant="info">Verified</Badge>
 							</Show>
 							<Show when={viewer()?.isOwner}>
-								<span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 font-medium text-purple-800 text-sm">
-									Owner
-								</span>
+								<Badge variant="info">Owner</Badge>
 							</Show>
 							<Show when={viewer()?.isModerator}>
-								<span class="inline-flex items-center rounded-full bg-green-100 px-3 py-1 font-medium text-green-800 text-sm">
-									Moderator
-								</span>
+								<Badge variant="success">Moderator</Badge>
 							</Show>
 							<Show when={viewer()?.isPatreon}>
-								<span class="inline-flex items-center rounded-full bg-pink-100 px-3 py-1 font-medium text-pink-800 text-sm">
-									Patron
-								</span>
+								<Badge variant="warning">Patron</Badge>
 							</Show>
 						</div>
 					</div>
 
 					{/* Activity Info */}
-					<div class="rounded-lg bg-white p-6 shadow">
-						<h3 class="mb-4 font-medium text-gray-900 text-lg">
-							Activity Info
-						</h3>
+					<Card class="p-6">
+						<h3 class={`${text.h3} mb-4`}>Activity Info</h3>
 						<dl class="space-y-3">
 							<div>
 								<dt class="font-medium text-gray-500 text-sm">First Seen</dt>
@@ -459,14 +458,14 @@ export default function ViewerDetail() {
 								</div>
 							</Show>
 						</dl>
-					</div>
+					</Card>
 
 					{/* Recent Messages */}
-					<div class="rounded-lg border border-gray-200 bg-white shadow-sm">
+					<Card>
 						<div class="border-gray-200 border-b px-6 py-4">
-							<h3 class="font-medium text-gray-900 text-lg">
+							<h3 class={text.h3}>
 								Recent Messages
-								<span class="ml-2 text-gray-500 text-sm">
+								<span class={`${text.muted} ml-2 text-sm`}>
 									({messages().length})
 								</span>
 							</h3>
@@ -500,17 +499,15 @@ export default function ViewerDetail() {
 										<div class="p-6">
 											<div class="mb-1 flex items-center space-x-2">
 												<Show when={message.platform}>
-													<span
-														class={`inline-flex items-center rounded px-2 py-0.5 font-medium text-xs ${platformBadgeColor(
+													<Badge
+														variant={getPlatformBadgeVariant(
 															message.platform ?? "",
-														)}`}>
+														)}>
 														{platformName(message.platform ?? "")}
-													</span>
+													</Badge>
 												</Show>
 												<Show when={message.senderIsModerator}>
-													<span class="inline-flex items-center rounded bg-green-100 px-2 py-0.5 font-medium text-green-800 text-xs">
-														Moderator
-													</span>
+													<Badge variant="success">Moderator</Badge>
 												</Show>
 												<Show when={message.livestreamId}>
 													<button
@@ -536,14 +533,14 @@ export default function ViewerDetail() {
 								</For>
 							</div>
 						</Show>
-					</div>
+					</Card>
 
 					{/* Recent Events */}
-					<div class="rounded-lg border border-gray-200 bg-white shadow-sm">
+					<Card>
 						<div class="border-gray-200 border-b px-6 py-4">
-							<h3 class="font-medium text-gray-900 text-lg">
+							<h3 class={text.h3}>
 								Recent Events
-								<span class="ml-2 text-gray-500 text-sm">
+								<span class={`${text.muted} ml-2 text-sm`}>
 									({events().length})
 								</span>
 							</h3>
@@ -576,16 +573,14 @@ export default function ViewerDetail() {
 									{(event) => (
 										<div class="p-6">
 											<div class="mb-1 flex items-center space-x-2">
-												<span class="inline-flex items-center rounded bg-purple-100 px-2 py-0.5 font-medium text-purple-800 text-xs">
-													{event.type}
-												</span>
+												<Badge variant="info">{event.type}</Badge>
 												<Show when={event.platform}>
-													<span
-														class={`inline-flex items-center rounded px-2 py-0.5 font-medium text-xs ${platformBadgeColor(
+													<Badge
+														variant={getPlatformBadgeVariant(
 															event.platform ?? "",
-														)}`}>
+														)}>
 														{platformName(event.platform ?? "")}
-													</span>
+													</Badge>
 												</Show>
 												<Show when={event.livestreamId}>
 													<button
@@ -613,7 +608,7 @@ export default function ViewerDetail() {
 								</For>
 							</div>
 						</Show>
-					</div>
+					</Card>
 				</div>
 			</Show>
 		</>

--- a/frontend/src/routes/dashboard/viewers/index.tsx
+++ b/frontend/src/routes/dashboard/viewers/index.tsx
@@ -1,10 +1,14 @@
 import { Title } from "@solidjs/meta";
 import { useNavigate } from "@solidjs/router";
 import { createEffect, createSignal, For, Show } from "solid-js";
-import { Skeleton, SkeletonListItem } from "~/components/ui";
+import Badge from "~/components/ui/Badge";
+import Button from "~/components/ui/Button";
+import Card from "~/components/ui/Card";
+import Input, { Select } from "~/components/ui/Input";
+import { Skeleton } from "~/components/ui";
 import { getLoginUrl, useCurrentUser } from "~/lib/auth";
 import { listBannedViewers, listViewers, searchViewers } from "~/sdk/ash_rpc";
-import { badge, button, card, input, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
 
 type Platform = "twitch" | "youtube" | "facebook" | "kick" | "";
 type ViewMode = "viewers" | "banned";
@@ -20,7 +24,7 @@ function ViewersPageSkeleton() {
 			</div>
 
 			{/* Filters skeleton */}
-			<div class={card.default}>
+			<Card>
 				<Skeleton class="mb-4 h-6 w-16" />
 				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 					<For each={[1, 2]}>
@@ -32,10 +36,10 @@ function ViewersPageSkeleton() {
 						)}
 					</For>
 				</div>
-			</div>
+			</Card>
 
 			{/* Viewers list skeleton */}
-			<div class={card.default}>
+			<Card>
 				<Skeleton class="mb-4 h-6 w-20" />
 				<div class="space-y-3">
 					<For each={[1, 2, 3, 4, 5, 6]}>
@@ -56,7 +60,7 @@ function ViewersPageSkeleton() {
 						)}
 					</For>
 				</div>
-			</div>
+			</Card>
 		</div>
 	);
 }
@@ -320,16 +324,16 @@ export default function Viewers() {
 		return `${diffDays}d ago`;
 	};
 
-	const getPlatformBadgeColor = (platformName: string) => {
-		const colors = {
-			twitch: badge.info,
-			youtube: badge.error,
-			facebook: badge.info,
-			kick: badge.success,
+	const getPlatformBadgeVariant = (
+		platformName: string,
+	): "info" | "error" | "success" | "neutral" => {
+		const variants: Record<string, "info" | "error" | "success" | "neutral"> = {
+			twitch: "info",
+			youtube: "error",
+			facebook: "info",
+			kick: "success",
 		};
-		return (
-			colors[platformName.toLowerCase() as keyof typeof colors] || badge.neutral
-		);
+		return variants[platformName.toLowerCase()] || "neutral";
 	};
 
 	return (
@@ -383,7 +387,7 @@ export default function Viewers() {
 						{/* Viewers View */}
 						<Show when={viewMode() === "viewers"}>
 							{/* Filters Section */}
-							<div class={card.default}>
+							<Card>
 								<h3 class={`${text.h3} mb-4`}>Filters</h3>
 
 								<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -391,8 +395,8 @@ export default function Viewers() {
 									<div>
 										<label class="block font-medium text-gray-700 text-sm">
 											Platform
-											<select
-												class={`mt-2 ${input.select}`}
+											<Select
+												class="mt-2"
 												value={platform()}
 												onChange={(e) => {
 													setPlatform(e.currentTarget.value as Platform);
@@ -403,7 +407,7 @@ export default function Viewers() {
 												<option value="youtube">YouTube</option>
 												<option value="facebook">Facebook</option>
 												<option value="kick">Kick</option>
-											</select>
+											</Select>
 										</label>
 									</div>
 
@@ -412,9 +416,9 @@ export default function Viewers() {
 										<label class="block font-medium text-gray-700 text-sm">
 											Search
 											<form onSubmit={handleSearch}>
-												<input
+												<Input
 													type="text"
-													class={`mt-2 ${input.text}`}
+													class="mt-2"
 													placeholder="Search by display name..."
 													value={searchInput()}
 													onInput={(e) => setSearchInput(e.currentTarget.value)}
@@ -429,10 +433,10 @@ export default function Viewers() {
 									<div class="mt-4 flex items-center gap-2 text-gray-600 text-sm">
 										<span class="font-medium">Active filters:</span>
 										<Show when={platform()}>
-											<span class={badge.info}>{platform()}</span>
+											<Badge variant="info">{platform()}</Badge>
 										</Show>
 										<Show when={search()}>
-											<span class={badge.info}>"{search()}"</span>
+											<Badge variant="info">"{search()}"</Badge>
 										</Show>
 										<button
 											type="button"
@@ -447,7 +451,7 @@ export default function Viewers() {
 										</button>
 									</div>
 								</Show>
-							</div>
+							</Card>
 
 							{/* Error Message */}
 							<Show when={error()}>
@@ -457,7 +461,7 @@ export default function Viewers() {
 							</Show>
 
 							{/* Viewers List */}
-							<div class={card.default}>
+							<Card>
 								<h3 class={`${text.h3} mb-4`}>Viewers</h3>
 
 								<Show
@@ -524,22 +528,20 @@ export default function Viewers() {
 																	<h4 class="font-semibold text-gray-900">
 																		{viewer.displayName}
 																	</h4>
-																	<span
-																		class={getPlatformBadgeColor(
+																	<Badge
+																		variant={getPlatformBadgeVariant(
 																			viewer.platform,
 																		)}>
 																		{viewer.platform}
-																	</span>
+																	</Badge>
 																	<Show when={viewer.isOwner}>
-																		<span class="inline-flex items-center rounded bg-yellow-100 px-2 py-0.5 font-medium text-xs text-yellow-800">
-																			Owner
-																		</span>
+																		<Badge variant="warning">Owner</Badge>
 																	</Show>
 																	<Show when={viewer.isVerified}>
-																		<span class={badge.success}>Verified</span>
+																		<Badge variant="success">Verified</Badge>
 																	</Show>
 																	<Show when={viewer.isModerator}>
-																		<span class={badge.success}>MOD</span>
+																		<Badge variant="success">MOD</Badge>
 																	</Show>
 																	<Show when={viewer.isPatreon}>
 																		<span class="inline-flex items-center rounded bg-pink-100 px-2 py-0.5 font-medium text-pink-800 text-xs">
@@ -569,18 +571,16 @@ export default function Viewers() {
 										{/* Load More Button */}
 										<Show when={hasMore()}>
 											<div class="mt-6 text-center">
-												<button
-													type="button"
-													class={button.primary}
+												<Button
 													onClick={loadMore}
 													disabled={isLoadingViewers()}>
 													{isLoadingViewers() ? "Loading..." : "Load More"}
-												</button>
+												</Button>
 											</div>
 										</Show>
 									</Show>
 								</Show>
-							</div>
+							</Card>
 						</Show>
 
 						{/* Banned Viewers View */}
@@ -593,7 +593,7 @@ export default function Viewers() {
 							</Show>
 
 							{/* Banned Viewers List */}
-							<div class={card.default}>
+							<Card>
 								<h3 class={`${text.h3} mb-4`}>Banned Viewers</h3>
 
 								<Show
@@ -635,17 +635,17 @@ export default function Viewers() {
 																	<span class="font-semibold text-gray-900">
 																		{banned.viewerUsername}
 																	</span>
-																	<span
-																		class={getPlatformBadgeColor(
+																	<Badge
+																		variant={getPlatformBadgeVariant(
 																			banned.platform,
 																		)}>
 																		{banned.platform}
-																	</span>
+																	</Badge>
 																	<Show when={!banned.durationSeconds}>
-																		<span class={badge.error}>Permanent</span>
+																		<Badge variant="error">Permanent</Badge>
 																	</Show>
 																	<Show when={banned.durationSeconds}>
-																		<span class={badge.warning}>
+																		<Badge variant="warning">
 																			{(banned.durationSeconds ?? 0) < 3600
 																				? `${Math.floor(
 																						(banned.durationSeconds ?? 0) / 60,
@@ -654,7 +654,7 @@ export default function Viewers() {
 																						(banned.durationSeconds ?? 0) /
 																							3600,
 																					)}h timeout`}
-																		</span>
+																		</Badge>
 																	</Show>
 																</div>
 
@@ -679,14 +679,14 @@ export default function Viewers() {
 															</div>
 
 															{/* Unban Button */}
-															<button
-																type="button"
-																class="rounded bg-red-600 px-3 py-1 text-sm text-white transition-colors hover:bg-red-700"
+															<Button
+																variant="danger"
+																size="sm"
 																onClick={() => {
 																	console.log("Unban viewer:", banned.id);
 																}}>
 																Unban
-															</button>
+															</Button>
 														</div>
 													</div>
 												)}
@@ -694,7 +694,7 @@ export default function Viewers() {
 										</div>
 									</Show>
 								</Show>
-							</div>
+							</Card>
 						</Show>
 					</div>
 				</Show>

--- a/frontend/src/routes/dashboard/widgets/[slug].tsx
+++ b/frontend/src/routes/dashboard/widgets/[slug].tsx
@@ -15,7 +15,8 @@ import { useParams, useNavigate } from "@solidjs/router";
 import { Show, createMemo } from "solid-js";
 import { WidgetSettingsPage } from "~/components/WidgetSettingsPage";
 import { getWidgetDefinition } from "~/lib/widget-registry";
-import { text, button } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
+import Button from "~/components/ui/Button";
 
 export default function WidgetSettingsRoute() {
 	const params = useParams<{ slug: string }>();
@@ -30,12 +31,9 @@ export default function WidgetSettingsRoute() {
 				<div class="space-y-4 text-center">
 					<h1 class={text.h1}>Widget Not Found</h1>
 					<p class={text.muted}>The widget "{params.slug}" does not exist.</p>
-					<button
-						type="button"
-						class={button.primary}
-						onClick={() => navigate("/dashboard/widgets")}>
+					<Button type="button" onClick={() => navigate("/dashboard/widgets")}>
 						Back to Widgets
-					</button>
+					</Button>
 				</div>
 			}>
 			{(def) => (

--- a/frontend/src/routes/dashboard/widgets/index.tsx
+++ b/frontend/src/routes/dashboard/widgets/index.tsx
@@ -7,7 +7,10 @@ import {
 	getWidgetCategories,
 	type WidgetCatalogEntry,
 } from "~/lib/widget-registry";
-import { badge, button, card, text } from "~/styles/design-system";
+import { text } from "~/styles/design-system";
+import Button from "~/components/ui/Button";
+import Card from "~/components/ui/Card";
+import Badge from "~/components/ui/Badge";
 
 // Get widgets and categories from the central registry
 const widgets = getWidgetCatalog();
@@ -56,43 +59,41 @@ export default function Widgets() {
 					}>
 					<div class="mx-auto max-w-7xl space-y-6">
 						{/* Header */}
-						<div class={card.default}>
+						<Card>
 							<h1 class={text.h1}>Stream Widgets</h1>
 							<p class={`${text.muted} mt-2`}>
 								Customize your stream with beautiful, interactive widgets for
 								OBS
 							</p>
-						</div>
+						</Card>
 
 						{/* Category Filter */}
-						<div class={card.default}>
+						<Card>
 							<div class="flex flex-wrap gap-2">
 								<For each={categories}>
 									{(category) => (
-										<button
+										<Button
 											type="button"
-											class={
+											variant={
 												selectedCategory() === category.value
-													? button.primary
-													: button.secondary
+													? "primary"
+													: "secondary"
 											}
 											onClick={() => setSelectedCategory(category.value)}>
 											{category.name}
-										</button>
+										</Button>
 									)}
 								</For>
 							</div>
-						</div>
+						</Card>
 
 						{/* Widgets Grid */}
 						<div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
 							<For each={filteredWidgets()}>
 								{(widget) => (
-									<div
-										class={
-											card.base +
-											"overflow-hidden transition-shadow hover:shadow-lg"
-										}>
+									<Card
+										padding="none"
+										class="overflow-hidden transition-shadow hover:shadow-lg">
 										{/* Widget Icon Header */}
 										<div class="bg-linear-to-r from-purple-500 to-pink-500 p-6 text-center">
 											<div class="mb-2 text-6xl">{widget.icon}</div>
@@ -104,12 +105,12 @@ export default function Widgets() {
 										{/* Widget Content */}
 										<div class="p-6">
 											<div class="mb-3 flex items-center gap-2">
-												<span class={badge.info}>{widget.category}</span>
+												<Badge variant="info">{widget.category}</Badge>
 												<Show when={widget.status === "coming-soon"}>
-													<span class={badge.warning}>Coming Soon</span>
+													<Badge variant="warning">Coming Soon</Badge>
 												</Show>
 												<Show when={widget.priority === "high"}>
-													<span class={badge.success}>Popular</span>
+													<Badge variant="success">Popular</Badge>
 												</Show>
 											</div>
 
@@ -121,23 +122,22 @@ export default function Widgets() {
 												<Show
 													when={widget.status === "available"}
 													fallback={
-														<button
-															type="button"
-															class={button.secondary}
-															disabled>
+														<Button type="button" variant="secondary" disabled>
 															Configure
-														</button>
+														</Button>
 													}>
-													<A
+													<Button
+														as="link"
 														href={widget.settingsRoute}
-														class={`${button.primary} flex-1 text-center`}>
+														class="flex-1 text-center">
 														Configure
-													</A>
+													</Button>
 												</Show>
 												<Show when={widget.status === "available"}>
-													<a
+													<Button
+														as="a"
 														href={`${widget.displayRoute}/${user()?.id}`}
-														class={button.ghost}
+														variant="ghost"
 														target="_blank"
 														rel="noopener noreferrer">
 														<span class="sr-only">
@@ -156,11 +156,11 @@ export default function Widgets() {
 																d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
 															/>
 														</svg>
-													</a>
+													</Button>
 												</Show>
 											</div>
 										</div>
-									</div>
+									</Card>
 								)}
 							</For>
 						</div>

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -283,7 +283,7 @@ export default function LoginPage() {
 								disabled={isSubmitting()}
 								class="flex w-full items-center justify-center gap-2 rounded-lg bg-linear-to-r from-purple-500 to-pink-500 px-4 py-3 font-semibold text-white transition-all hover:from-purple-600 hover:to-pink-600 disabled:cursor-not-allowed disabled:opacity-50">
 								<EmailIcon />
-									{isSubmitting()
+								{isSubmitting()
 									? t("common.pleaseWait")
 									: mode() === "signin"
 										? t("auth.signInWithEmail")

--- a/frontend/src/styles/design-system.ts
+++ b/frontend/src/styles/design-system.ts
@@ -1,43 +1,13 @@
 /**
- * Design System - Reusable component class patterns
- * Update CSS variables in app.css to change colors globally.
+ * Design System - Reusable utilities
+ *
+ * Note: Most component-level styles have been migrated to UI components in ~/components/ui/
+ * - Button: ~/components/ui/Button.tsx
+ * - Card: ~/components/ui/Card.tsx
+ * - Badge: ~/components/ui/Badge.tsx
+ * - Alert: ~/components/ui/Alert.tsx
+ * - Input/Select/Textarea: ~/components/ui/Input.tsx
  */
-
-export const button = {
-	primary:
-		"bg-purple-600 text-white px-4 py-2 rounded-lg hover:bg-purple-700 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed",
-	secondary:
-		"bg-gray-200 text-gray-900 px-4 py-2 rounded-lg hover:bg-gray-300 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed",
-	danger:
-		"bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed",
-	success:
-		"bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed",
-	ghost:
-		"text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-100 transition-colors font-medium",
-	icon: "p-2 rounded-lg hover:bg-gray-100 transition-colors flex items-center justify-center",
-	gradient:
-		"bg-linear-to-r from-purple-600 to-pink-500 text-white px-6 py-3 rounded-lg hover:from-purple-700 hover:to-pink-600 transition-all font-semibold shadow-md",
-};
-
-export const input = {
-	text: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:bg-gray-50 disabled:cursor-not-allowed",
-	error:
-		"w-full border border-red-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-red-500 focus:border-transparent",
-	select:
-		"w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:border-transparent bg-white",
-	textarea:
-		"w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none",
-};
-
-export const card = {
-	base: "bg-white border border-gray-200 rounded-2xl shadow-sm",
-	default: "bg-white border border-gray-200 rounded-2xl shadow-sm p-6",
-	interactive:
-		"bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition-shadow cursor-pointer",
-	gradient:
-		"bg-linear-to-r from-purple-600 to-pink-600 rounded-lg shadow-sm p-6 text-white",
-	section: "bg-white rounded-lg shadow-sm border border-gray-200 p-6",
-};
 
 export const text = {
 	h1: "text-3xl font-bold text-gray-900",
@@ -50,28 +20,6 @@ export const text = {
 	helper: "text-xs text-gray-500",
 	error: "text-sm text-red-600",
 	success: "text-sm text-green-600",
-};
-
-export const badge = {
-	success:
-		"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800",
-	warning:
-		"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800",
-	error:
-		"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800",
-	info: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800",
-	neutral:
-		"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800",
-};
-
-export const alert = {
-	success:
-		"flex items-start space-x-3 p-3 bg-green-50 rounded-lg border border-green-200",
-	warning:
-		"flex items-start space-x-3 p-3 bg-yellow-50 rounded-lg border border-yellow-200",
-	error:
-		"flex items-start space-x-3 p-3 bg-red-50 rounded-lg border border-red-200",
-	info: "flex items-start space-x-3 p-3 bg-blue-50 rounded-lg border border-blue-200",
 };
 
 export const link = {


### PR DESCRIPTION
## Summary
- Replaced native `button`, `input`, `select` elements with `Button`, `Card`, `Badge`, `Input`, `Select` UI components
- Migrated all dashboard pages to use UI components instead of CSS class strings (`button.primary`, `card.base`, etc.)
- Migrated WidgetSettingsPage, schema-form fields, and widget-registry to use UI components
- Updated LanguageSwitcher and StreamingAccountStats components
- Cleaned up design-system.ts by removing unused exports (`button`, `input`, `card`, `badge`, `alert`)
- Kept utilities still in use: `text`, `layout`, `chart`, `skeleton`, `cn()`

## Test plan
- [x] Build passes (`bun run build`)
- [x] Typecheck passes (only pre-existing storybook errors)
- [x] Verified pages render correctly with Playwright headless testing
- [x] Home page, login page, contact page all render properly
- [ ] Manual testing of dashboard pages when logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)