### PR TITLE
Refactor: Extract shared HTTP response handling and fix Logger warnings

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -27,16 +27,43 @@ alias Credo.Check.Readability.ModuleDoc
           {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig,
            [
              metadata_keys: [
+               # Request tracking
                :request_id,
                :error_id,
                :user_id,
                :path,
                :duration,
+               # Stream management
                :livestream_id,
+               :stream_id,
                :component,
                :chat_id,
                :input_status,
-               :stream_id
+               # API response handling
+               :status,
+               :body,
+               :reason,
+               :error,
+               :error_type,
+               :stacktrace,
+               # TTS processing
+               :voice,
+               :voice_name,
+               :audio_size,
+               :message_length,
+               :hash,
+               :has_tts,
+               # Webhook/notification handling
+               :webhook_id,
+               :event_type,
+               :event_id,
+               :retry_after,
+               :attempt,
+               # Donation processing
+               :donor_name,
+               :amount,
+               # File operations
+               :size
              ]
            ]}
         ],

--- a/config/config.exs
+++ b/config/config.exs
@@ -45,16 +45,43 @@ config :logger, :console,
   level: :info,
   format: "$time $metadata[$level] $message\n",
   metadata: [
+    # Request tracking
     :request_id,
     :error_id,
     :user_id,
     :path,
     :duration,
+    # Stream management
     :livestream_id,
+    :stream_id,
     :component,
     :chat_id,
     :input_status,
-    :stream_id
+    # API response handling
+    :status,
+    :body,
+    :reason,
+    :error,
+    :error_type,
+    :stacktrace,
+    # TTS processing
+    :voice,
+    :voice_name,
+    :audio_size,
+    :message_length,
+    :hash,
+    :has_tts,
+    # Webhook/notification handling
+    :webhook_id,
+    :event_type,
+    :event_id,
+    :retry_after,
+    :attempt,
+    # Donation processing
+    :donor_name,
+    :amount,
+    # File operations
+    :size
   ]
 
 config :phoenix, :json_library, Jason

--- a/lib/streampai/http/response_handler.ex
+++ b/lib/streampai/http/response_handler.ex
@@ -1,0 +1,86 @@
+defmodule Streampai.HTTP.ResponseHandler do
+  @moduledoc """
+  Shared HTTP response handling utilities for API clients.
+
+  This module provides consistent response parsing and error handling
+  across all API clients (YouTube, Twitch, PayPal, Cloudflare, etc.).
+
+  ## Usage
+
+      # In your API client module:
+      import Streampai.HTTP.ResponseHandler, only: [handle_http_response: 2]
+
+      def some_api_call(params) do
+        Req.get(url: "...", params: params)
+        |> handle_http_response("SomeAPI")
+      end
+
+  ## Response Format
+
+  All handlers return:
+  - `{:ok, body}` for successful responses (2xx status codes)
+  - `{:error, {:http_error, status, body}}` for HTTP errors
+  - `{:error, reason}` for connection/transport errors
+  """
+
+  require Logger
+
+  @type http_response :: {:ok, Req.Response.t()} | {:error, term()}
+  @type api_name :: String.t()
+  @type result :: {:ok, map() | binary()} | {:error, term()}
+
+  @doc """
+  Handles HTTP responses from Req library with consistent error handling and logging.
+
+  ## Parameters
+  - `response` - The response tuple from Req.get/post/etc
+  - `api_name` - Name of the API for logging (e.g., "YouTube", "Twitch", "PayPal")
+
+  ## Examples
+
+      iex> handle_http_response({:ok, %{status: 200, body: %{"data" => []}}}, "YouTube")
+      {:ok, %{"data" => []}}
+
+      iex> handle_http_response({:ok, %{status: 401, body: %{"error" => "unauthorized"}}}, "Twitch")
+      {:error, {:http_error, 401, %{"error" => "unauthorized"}}}
+
+      iex> handle_http_response({:error, :timeout}, "PayPal")
+      {:error, :timeout}
+  """
+  @spec handle_http_response(http_response(), api_name()) :: result()
+  def handle_http_response({:ok, %{status: status, body: body}}, _api_name)
+      when status in 200..299 do
+    {:ok, body}
+  end
+
+  def handle_http_response({:ok, %{status: status, body: body}}, api_name) do
+    Logger.warning("#{api_name} API request failed with status #{status}: #{inspect(body)}")
+    {:error, {:http_error, status, body}}
+  end
+
+  def handle_http_response({:error, reason}, api_name) do
+    Logger.error("#{api_name} API request failed: #{inspect(reason)}")
+    {:error, reason}
+  end
+
+  @doc """
+  Handles raw Req.Response structs (without the tuple wrapper).
+
+  Useful when you've already extracted the response from the tuple.
+
+  ## Examples
+
+      iex> handle_raw_response(%{status: 200, body: %{"data" => []}}, "API")
+      {:ok, %{"data" => []}}
+  """
+  @spec handle_raw_response(Req.Response.t(), api_name()) :: result()
+  def handle_raw_response(%{status: status, body: body}, _api_name)
+      when status in 200..299 do
+    {:ok, body}
+  end
+
+  def handle_raw_response(%{status: status, body: body}, api_name) do
+    Logger.warning("#{api_name} API error #{status}: #{inspect(body)}")
+    {:error, {:http_error, status, body}}
+  end
+end

--- a/lib/streampai/integrations/paypal/client.ex
+++ b/lib/streampai/integrations/paypal/client.ex
@@ -7,6 +7,8 @@ defmodule Streampai.Integrations.PayPal.Client do
   """
   require Logger
 
+  import Streampai.HTTP.ResponseHandler, only: [handle_raw_response: 2]
+
   @sandbox_base_url "https://api.sandbox.paypal.com"
   @production_base_url "https://api.paypal.com"
 
@@ -70,7 +72,7 @@ defmodule Streampai.Integrations.PayPal.Client do
     with {:ok, token} <- get_or_refresh_token(),
          {:ok, headers} <- build_headers(token, opts),
          {:ok, response} <- make_request(method, path, body, headers) do
-      handle_response(response)
+      handle_raw_response(response, "PayPal")
     end
   end
 
@@ -133,15 +135,6 @@ defmodule Streampai.Integrations.PayPal.Client do
       {k, v} when is_binary(k) -> {String.downcase(k), v}
       {k, v} -> {k, v}
     end)
-  end
-
-  defp handle_response(%{status: status, body: body}) when status in 200..299 do
-    {:ok, body}
-  end
-
-  defp handle_response(%{status: status, body: body}) do
-    Logger.warning("PayPal API error #{status}: #{inspect(body)}")
-    {:error, {:http_error, status, body}}
   end
 
   defp generate_auth_assertion(merchant_id) do

--- a/lib/streampai/twitch/api_client.ex
+++ b/lib/streampai/twitch/api_client.ex
@@ -11,6 +11,8 @@ defmodule Streampai.Twitch.ApiClient do
 
   require Logger
 
+  import Streampai.HTTP.ResponseHandler, only: [handle_http_response: 2]
+
   @base_url "https://api.twitch.tv/helix"
   @default_timeout 30_000
 
@@ -51,7 +53,7 @@ defmodule Streampai.Twitch.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("Twitch")
     |> extract_stream_key()
   end
 
@@ -84,7 +86,7 @@ defmodule Streampai.Twitch.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("Twitch")
     |> extract_stream_data()
   end
 
@@ -129,7 +131,7 @@ defmodule Streampai.Twitch.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.patch()
-    |> handle_response()
+    |> handle_http_response("Twitch")
   end
 
   @doc """
@@ -159,7 +161,7 @@ defmodule Streampai.Twitch.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("Twitch")
     |> extract_first_user()
   end
 
@@ -205,7 +207,7 @@ defmodule Streampai.Twitch.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.post()
-    |> handle_response()
+    |> handle_http_response("Twitch")
   end
 
   @doc """
@@ -263,7 +265,7 @@ defmodule Streampai.Twitch.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.post()
-    |> handle_response()
+    |> handle_http_response("Twitch")
     |> extract_first_ban()
   end
 
@@ -351,7 +353,7 @@ defmodule Streampai.Twitch.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("Twitch")
     |> case do
       {:ok, %{"total" => total}} -> {:ok, %{follower_count: total}}
       {:ok, response} -> {:error, {:unexpected_response, response}}
@@ -393,7 +395,7 @@ defmodule Streampai.Twitch.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("Twitch")
     |> case do
       {:ok, %{"total" => total, "points" => points}} ->
         {:ok, %{subscriber_count: total, points: points}}
@@ -450,20 +452,6 @@ defmodule Streampai.Twitch.ApiClient do
   end
 
   ## Private Functions
-
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    {:ok, body}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    Logger.warning("Twitch API request failed with status #{status}: #{inspect(body)}")
-    {:error, {:http_error, status, body}}
-  end
-
-  defp handle_response({:error, reason}) do
-    Logger.error("Twitch API request failed: #{inspect(reason)}")
-    {:error, reason}
-  end
 
   defp extract_stream_key({:ok, %{"data" => [%{"stream_key" => stream_key}]}}) do
     {:ok, stream_key}

--- a/lib/streampai/youtube/api_client.ex
+++ b/lib/streampai/youtube/api_client.ex
@@ -14,6 +14,8 @@ defmodule Streampai.YouTube.ApiClient do
 
   require Logger
 
+  import Streampai.HTTP.ResponseHandler, only: [handle_http_response: 2]
+
   @base_url "https://www.googleapis.com/youtube/v3"
   @analytics_url "https://youtubeanalytics.googleapis.com/v2"
   @token_info_url "https://www.googleapis.com/oauth2/v3/tokeninfo"
@@ -62,7 +64,7 @@ defmodule Streampai.YouTube.ApiClient do
       receive_timeout: @default_timeout
     ]
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   ## Live Chat Messages API
@@ -113,7 +115,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.post()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -131,7 +133,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.delete()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -175,7 +177,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.post()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -192,7 +194,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.delete()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   ## Live Broadcasts API
@@ -236,7 +238,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -264,7 +266,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts = base_opts(access_token) ++ [url: "/liveBroadcasts", params: params]
 
-    case req_opts |> Req.get() |> handle_response() do
+    case req_opts |> Req.get() |> handle_http_response("YouTube") do
       {:ok, %{"items" => [broadcast | _]}} -> {:ok, broadcast}
       {:ok, %{"items" => []}} -> {:error, :not_found}
       error -> error
@@ -310,7 +312,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.post()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -337,7 +339,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.put()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -371,7 +373,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.post()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -401,7 +403,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.post()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -428,7 +430,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("YouTube")
     |> case do
       {:ok, %{"items" => []}} ->
         {:error, :video_not_found}
@@ -465,7 +467,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.delete()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   ## Live Streams API
@@ -505,7 +507,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -546,7 +548,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.post()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -572,7 +574,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.put()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   @doc """
@@ -599,7 +601,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.delete()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   ## Members API
@@ -641,7 +643,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.get()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   ## Thumbnails API
@@ -693,7 +695,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts
     |> Req.request()
-    |> handle_response()
+    |> handle_http_response("YouTube")
   end
 
   ## Utility Functions
@@ -738,7 +740,7 @@ defmodule Streampai.YouTube.ApiClient do
     params = %{part: "statistics", mine: true}
     req_opts = base_opts(access_token) ++ [url: "/channels", params: params]
 
-    case req_opts |> Req.get() |> handle_response() do
+    case req_opts |> Req.get() |> handle_http_response("YouTube") do
       {:ok, %{"items" => [channel | _]}} ->
         stats = get_in(channel, ["statistics"]) || %{}
 
@@ -791,7 +793,7 @@ defmodule Streampai.YouTube.ApiClient do
       receive_timeout: @default_timeout
     ]
 
-    case req_opts |> Req.get() |> handle_response() do
+    case req_opts |> Req.get() |> handle_http_response("YouTube") do
       {:ok, %{"rows" => [[views, _watch_time] | _]}} ->
         # Note: Unique viewers is not available via YouTube Analytics API
         # It's only available in YouTube Studio interface
@@ -835,7 +837,7 @@ defmodule Streampai.YouTube.ApiClient do
 
     req_opts = base_opts(access_token) ++ [url: "/members", params: params]
 
-    case req_opts |> Req.get() |> handle_response() do
+    case req_opts |> Req.get() |> handle_http_response("YouTube") do
       {:ok, %{"items" => items, "nextPageToken" => next_token}} when is_list(items) ->
         count_members(access_token, next_token, acc + length(items))
 
@@ -893,20 +895,5 @@ defmodule Streampai.YouTube.ApiClient do
       {key, value} when is_atom(key) -> {Atom.to_string(key), value}
       {key, value} -> {key, value}
     end)
-  end
-
-  # Handles HTTP responses consistently
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    {:ok, body}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    Logger.warning("YouTube API request failed with status #{status}: #{inspect(body)}")
-    {:error, {:http_error, status, body}}
-  end
-
-  defp handle_response({:error, reason}) do
-    Logger.error("YouTube API request failed: #{inspect(reason)}")
-    {:error, reason}
   end
 end


### PR DESCRIPTION
## Summary

- **Extract shared HTTP response handling**: Created `Streampai.HTTP.ResponseHandler` module to eliminate duplicate HTTP response handling code across YouTube, Twitch, and PayPal API clients. This reduces code duplication and ensures consistent error handling and logging across all external API integrations.

- **Fix 40 Credo warnings**: Added missing Logger metadata keys to both `config/config.exs` and `.credo.exs`, eliminating all warnings about undefined metadata keys for TTS processing, webhook handling, donation processing, and API response handling.

- **No behavioral changes**: All existing tests pass (except for one pre-existing unrelated failure). The refactoring maintains identical functionality while improving code organization.

## Test plan

- [x] All unit tests pass (158 tests, 1 pre-existing failure unrelated to changes)
- [x] Credo analysis shows no issues (`mix credo --strict` passes)
- [x] Application compiles without warnings
- [x] Server starts and health endpoint responds correctly
- [x] API clients (YouTube, Twitch, PayPal) use shared response handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)