### PR TITLE
Add hover moderation actions to StreamControlsWidget

### DIFF
--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -11,8 +11,11 @@ export default function NotificationBell() {
 	const { locale } = useI18n();
 	const userId = createMemo(() => user()?.id);
 	// Pass the current locale to get localized notification content
-	const { data: allNotifications, unreadCount, isLoading } =
-		useNotificationsWithReadStatus(userId, locale);
+	const {
+		data: allNotifications,
+		unreadCount,
+		isLoading,
+	} = useNotificationsWithReadStatus(userId, locale);
 
 	const [isOpen, setIsOpen] = createSignal(false);
 	const [showUnreadOnly, setShowUnreadOnly] = createLocalStorageSignal(
@@ -149,95 +152,109 @@ export default function NotificationBell() {
 							<Show
 								when={notifications().length > 0}
 								fallback={
-								<div class="px-4 py-8 text-center text-gray-500">
-									<svg
-										aria-hidden="true"
-										class="mx-auto h-12 w-12 text-gray-300"
-										fill="none"
-										stroke="currentColor"
-										viewBox="0 0 24 24">
-										<path
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											stroke-width="2"
-											d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-										/>
-									</svg>
-									<p class="mt-2 text-sm">
-										{showUnreadOnly()
-											? "All caught up!"
-											: "No notifications yet"}
-									</p>
-								</div>
-							}>
-							<For each={notifications()}>
-								{(notification) => (
-									<div
-										class={`border-gray-100 border-b px-4 py-3 transition-colors last:border-b-0 hover:bg-gray-50 ${
-											notification.wasSeen ? "opacity-60" : ""
-										}`}>
-										<div class="flex items-start gap-3">
-											<div class="mt-1 shrink-0">
-												<Show
-													when={!notification.wasSeen}
-													fallback={
-														<div class="h-2 w-2 rounded-full bg-gray-300" />
-													}>
-													<div class="h-2 w-2 rounded-full bg-purple-500" />
-												</Show>
-											</div>
-											<div class="min-w-0 flex-1">
-												<p
-													class={`text-sm ${notification.wasSeen ? "text-gray-500" : "text-gray-900"}`}>
-													{notification.localizedContent}
-												</p>
-												<p class="mt-1 text-gray-400 text-xs">
-													{formatTimeAgo(notification.inserted_at)}
-												</p>
-											</div>
-											<button
-												type="button"
-												onClick={(e) => {
-													e.stopPropagation();
-													if (notification.wasSeen) {
-														handleMarkAsUnread(notification.id);
-													} else {
-														handleMarkAsRead(notification.id);
-													}
-												}}
-												disabled={markingRead() === notification.id}
-												class="shrink-0 rounded p-1 transition-colors hover:bg-gray-200"
-												title={
-													notification.wasSeen
-														? "Mark as unread"
-														: "Mark as read"
-												}>
-												<Show
-													when={markingRead() !== notification.id}
-													fallback={
-														<svg
-															aria-hidden="true"
-															class="h-4 w-4 animate-spin text-gray-400"
-															fill="none"
-															viewBox="0 0 24 24">
-															<circle
-																class="opacity-25"
-																cx="12"
-																cy="12"
-																r="10"
-																stroke="currentColor"
-																stroke-width="4"
-															/>
-															<path
-																class="opacity-75"
-																fill="currentColor"
-																d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-															/>
-														</svg>
-													}>
+									<div class="px-4 py-8 text-center text-gray-500">
+										<svg
+											aria-hidden="true"
+											class="mx-auto h-12 w-12 text-gray-300"
+											fill="none"
+											stroke="currentColor"
+											viewBox="0 0 24 24">
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width="2"
+												d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+											/>
+										</svg>
+										<p class="mt-2 text-sm">
+											{showUnreadOnly()
+												? "All caught up!"
+												: "No notifications yet"}
+										</p>
+									</div>
+								}>
+								<For each={notifications()}>
+									{(notification) => (
+										<div
+											class={`border-gray-100 border-b px-4 py-3 transition-colors last:border-b-0 hover:bg-gray-50 ${
+												notification.wasSeen ? "opacity-60" : ""
+											}`}>
+											<div class="flex items-start gap-3">
+												<div class="mt-1 shrink-0">
 													<Show
 														when={!notification.wasSeen}
 														fallback={
+															<div class="h-2 w-2 rounded-full bg-gray-300" />
+														}>
+														<div class="h-2 w-2 rounded-full bg-purple-500" />
+													</Show>
+												</div>
+												<div class="min-w-0 flex-1">
+													<p
+														class={`text-sm ${notification.wasSeen ? "text-gray-500" : "text-gray-900"}`}>
+														{notification.localizedContent}
+													</p>
+													<p class="mt-1 text-gray-400 text-xs">
+														{formatTimeAgo(notification.inserted_at)}
+													</p>
+												</div>
+												<button
+													type="button"
+													onClick={(e) => {
+														e.stopPropagation();
+														if (notification.wasSeen) {
+															handleMarkAsUnread(notification.id);
+														} else {
+															handleMarkAsRead(notification.id);
+														}
+													}}
+													disabled={markingRead() === notification.id}
+													class="shrink-0 rounded p-1 transition-colors hover:bg-gray-200"
+													title={
+														notification.wasSeen
+															? "Mark as unread"
+															: "Mark as read"
+													}>
+													<Show
+														when={markingRead() !== notification.id}
+														fallback={
+															<svg
+																aria-hidden="true"
+																class="h-4 w-4 animate-spin text-gray-400"
+																fill="none"
+																viewBox="0 0 24 24">
+																<circle
+																	class="opacity-25"
+																	cx="12"
+																	cy="12"
+																	r="10"
+																	stroke="currentColor"
+																	stroke-width="4"
+																/>
+																<path
+																	class="opacity-75"
+																	fill="currentColor"
+																	d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+																/>
+															</svg>
+														}>
+														<Show
+															when={!notification.wasSeen}
+															fallback={
+																<svg
+																	aria-hidden="true"
+																	class="h-4 w-4 text-gray-400"
+																	fill="none"
+																	stroke="currentColor"
+																	viewBox="0 0 24 24">
+																	<path
+																		stroke-linecap="round"
+																		stroke-linejoin="round"
+																		stroke-width="2"
+																		d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+																	/>
+																</svg>
+															}>
 															<svg
 																aria-hidden="true"
 																class="h-4 w-4 text-gray-400"
@@ -248,30 +265,16 @@ export default function NotificationBell() {
 																	stroke-linecap="round"
 																	stroke-linejoin="round"
 																	stroke-width="2"
-																	d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+																	d="M5 13l4 4L19 7"
 																/>
 															</svg>
-														}>
-														<svg
-															aria-hidden="true"
-															class="h-4 w-4 text-gray-400"
-															fill="none"
-															stroke="currentColor"
-															viewBox="0 0 24 24">
-															<path
-																stroke-linecap="round"
-																stroke-linejoin="round"
-																stroke-width="2"
-																d="M5 13l4 4L19 7"
-															/>
-														</svg>
+														</Show>
 													</Show>
-												</Show>
-											</button>
+												</button>
+											</div>
 										</div>
-									</div>
-								)}
-							</For>
+									)}
+								</For>
 							</Show>
 						</Show>
 					</div>

--- a/frontend/src/components/StreamControlsWidget.stories.tsx
+++ b/frontend/src/components/StreamControlsWidget.stories.tsx
@@ -5,6 +5,7 @@ import StreamControlsWidget, {
 	type StreamMetadata,
 	type StreamSummary,
 	type Platform,
+	type ModerationCallbacks,
 	PreStreamSettings,
 	LiveStreamControlCenter,
 	PostStreamSummary,
@@ -842,6 +843,142 @@ export const FilterTest: Story = {
 			description: {
 				story:
 					"Test story for verifying event filtering. Use the filter button to filter by event type, or the search box to find events by username or message content. Try searching for 'ChatFan' or 'amazing' to test text filtering.",
+			},
+		},
+	},
+};
+
+// =====================================================
+// Moderation Actions Test Story
+// =====================================================
+
+// Generate activities with viewer info for moderation testing
+const generateModerationTestActivities = (): ActivityItem[] => {
+	const now = Date.now();
+	return [
+		// Chat messages with viewer info for moderation
+		{
+			id: "chat-mod-1",
+			type: "chat" as const,
+			username: "ToxicUser",
+			message: "This is a test chat message that can be deleted",
+			platform: "twitch",
+			timestamp: new Date(now - 60000),
+			viewerId: "viewer-123",
+			viewerPlatformId: "twitch-user-123",
+		},
+		{
+			id: "chat-mod-2",
+			type: "chat" as const,
+			username: "AnotherChatter",
+			message: "Hello everyone! Hover over me to see moderation options.",
+			platform: "youtube",
+			timestamp: new Date(now - 50000),
+			viewerId: "viewer-456",
+			viewerPlatformId: "yt-user-456",
+		},
+		{
+			id: "chat-mod-3",
+			type: "chat" as const,
+			username: "SpamBot",
+			message: "Buy cheap stuff at spam.com!",
+			platform: "kick",
+			timestamp: new Date(now - 40000),
+			viewerId: "viewer-789",
+			viewerPlatformId: "kick-user-789",
+		},
+		// Important events with replay option
+		{
+			id: "donation-mod-1",
+			type: "donation" as const,
+			username: "GenerousDonor",
+			message: "Hover to replay this donation alert!",
+			amount: 50,
+			currency: "$",
+			platform: "twitch",
+			timestamp: new Date(now - 30000),
+			isImportant: true,
+		},
+		{
+			id: "sub-mod-1",
+			type: "subscription" as const,
+			username: "LoyalSubscriber",
+			message: "Hover to replay this sub alert!",
+			platform: "twitch",
+			timestamp: new Date(now - 20000),
+			isImportant: true,
+		},
+		{
+			id: "raid-mod-1",
+			type: "raid" as const,
+			username: "RaidLeader",
+			message: "Hover to replay this raid alert!",
+			platform: "twitch",
+			timestamp: new Date(now - 10000),
+			isImportant: true,
+		},
+		// More recent chat
+		{
+			id: "chat-mod-4",
+			type: "chat" as const,
+			username: "NiceViewer",
+			message: "Great stream! Love the new moderation features!",
+			platform: "twitch",
+			timestamp: new Date(now - 5000),
+			viewerId: "viewer-abc",
+			viewerPlatformId: "twitch-user-abc",
+		},
+	];
+};
+
+// Moderation callbacks for testing
+const moderationCallbacks: ModerationCallbacks = {
+	onReplayEvent: (eventId) => {
+		console.log(`Replay event: ${eventId}`);
+		alert(`Replaying alert for event: ${eventId}`);
+	},
+	onBanUser: (userId, platform, viewerPlatformId, username) => {
+		console.log(`Ban user: ${username} (${userId}) on ${platform}`);
+		alert(
+			`Banning user: ${username} on ${platform}\nViewer ID: ${viewerPlatformId}`,
+		);
+	},
+	onTimeoutUser: (
+		userId,
+		platform,
+		viewerPlatformId,
+		username,
+		durationSeconds,
+	) => {
+		const durationLabel =
+			durationSeconds >= 3600
+				? `${Math.floor(durationSeconds / 3600)}h`
+				: `${Math.floor(durationSeconds / 60)}m`;
+		console.log(`Timeout user: ${username} for ${durationLabel}`);
+		alert(`Timing out: ${username} for ${durationLabel} on ${platform}`);
+	},
+	onDeleteMessage: (eventId) => {
+		console.log(`Delete message: ${eventId}`);
+		alert(`Deleting message: ${eventId}`);
+	},
+};
+
+export const ModerationActionsTest: Story = {
+	args: {
+		phase: "live",
+		activities: generateModerationTestActivities(),
+		streamDuration: 1800,
+		viewerCount: 500,
+		stickyDuration: 120000,
+		connectedPlatforms: ["twitch", "youtube", "kick"],
+		onSendMessage: handleSendMessage,
+		moderationCallbacks,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Test story for moderation actions on hover. Hover over chat messages to see Ban, Timeout, and Delete options. Hover over important events (donations, subscriptions, raids) to see the Replay option.",
 			},
 		},
 	},

--- a/frontend/src/components/StreamControlsWidget.stories.tsx
+++ b/frontend/src/components/StreamControlsWidget.stories.tsx
@@ -305,6 +305,32 @@ const handleModifyTimers = () => console.log("Modify timers clicked");
 const handleChangeStreamSettings = () =>
 	console.log("Change stream settings clicked");
 
+// Default moderation callbacks for all live stories
+const defaultModerationCallbacks: ModerationCallbacks = {
+	onReplayEvent: (eventId) => {
+		console.log(`Replay event: ${eventId}`);
+	},
+	onBanUser: (userId, platform, viewerPlatformId, username) => {
+		console.log(`Ban user: ${username} (${userId}) on ${platform}`);
+	},
+	onTimeoutUser: (
+		userId,
+		platform,
+		viewerPlatformId,
+		username,
+		durationSeconds,
+	) => {
+		const durationLabel =
+			durationSeconds >= 3600
+				? `${Math.floor(durationSeconds / 3600)}h`
+				: `${Math.floor(durationSeconds / 60)}m`;
+		console.log(`Timeout user: ${username} for ${durationLabel}`);
+	},
+	onDeleteMessage: (eventId) => {
+		console.log(`Delete message: ${eventId}`);
+	},
+};
+
 export const Live: Story = {
 	args: {
 		phase: "live",
@@ -314,6 +340,7 @@ export const Live: Story = {
 		stickyDuration: 30000,
 		connectedPlatforms: ["twitch", "youtube", "kick"],
 		onSendMessage: handleSendMessage,
+		moderationCallbacks: defaultModerationCallbacks,
 		onStartPoll: handleStartPoll,
 		onStartGiveaway: handleStartGiveaway,
 		onModifyTimers: handleModifyTimers,
@@ -329,6 +356,7 @@ export const LiveEmpty: Story = {
 		viewerCount: 5,
 		connectedPlatforms: ["twitch"],
 		onSendMessage: handleSendMessage,
+		moderationCallbacks: defaultModerationCallbacks,
 		onStartPoll: handleStartPoll,
 		onStartGiveaway: handleStartGiveaway,
 		onModifyTimers: handleModifyTimers,
@@ -345,6 +373,7 @@ export const LiveBusy: Story = {
 		stickyDuration: 30000,
 		connectedPlatforms: ["twitch", "youtube", "kick", "facebook"],
 		onSendMessage: handleSendMessage,
+		moderationCallbacks: defaultModerationCallbacks,
 		onStartPoll: handleStartPoll,
 		onStartGiveaway: handleStartGiveaway,
 		onModifyTimers: handleModifyTimers,
@@ -362,6 +391,7 @@ export const LiveVirtualized: Story = {
 		stickyDuration: 30000,
 		connectedPlatforms: ["twitch", "youtube", "kick", "facebook"],
 		onSendMessage: handleSendMessage,
+		moderationCallbacks: defaultModerationCallbacks,
 		onStartPoll: handleStartPoll,
 		onStartGiveaway: handleStartGiveaway,
 		onModifyTimers: handleModifyTimers,
@@ -377,6 +407,7 @@ export const LiveChatOnly: Story = {
 		viewerCount: 150,
 		connectedPlatforms: ["twitch", "youtube"],
 		onSendMessage: handleSendMessage,
+		moderationCallbacks: defaultModerationCallbacks,
 		onStartPoll: handleStartPoll,
 		onStartGiveaway: handleStartGiveaway,
 		onModifyTimers: handleModifyTimers,
@@ -427,6 +458,7 @@ export const LiveManyDonations: Story = {
 		viewerCount: 2500,
 		connectedPlatforms: ["twitch", "youtube", "kick"],
 		onSendMessage: handleSendMessage,
+		moderationCallbacks: defaultModerationCallbacks,
 		onStartPoll: handleStartPoll,
 		onStartGiveaway: handleStartGiveaway,
 		onModifyTimers: handleModifyTimers,
@@ -601,6 +633,7 @@ function InteractiveLiveWrapper() {
 			stickyDuration={15000}
 			connectedPlatforms={["twitch", "youtube", "kick"]}
 			onSendMessage={handleSendMessage}
+			moderationCallbacks={defaultModerationCallbacks}
 		/>
 	);
 }
@@ -687,6 +720,7 @@ function StickyTestWrapper() {
 			onSendMessage={(msg, platforms) =>
 				console.log(`Send to ${platforms}: ${msg}`)
 			}
+			moderationCallbacks={defaultModerationCallbacks}
 		/>
 	);
 }
@@ -837,6 +871,7 @@ export const FilterTest: Story = {
 		viewerCount: 500,
 		connectedPlatforms: ["twitch", "youtube", "kick", "facebook"],
 		onSendMessage: handleSendMessage,
+		moderationCallbacks: defaultModerationCallbacks,
 	},
 	parameters: {
 		docs: {
@@ -931,8 +966,8 @@ const generateModerationTestActivities = (): ActivityItem[] => {
 	];
 };
 
-// Moderation callbacks for testing
-const moderationCallbacks: ModerationCallbacks = {
+// Moderation callbacks with alerts for testing (more visible feedback)
+const alertModerationCallbacks: ModerationCallbacks = {
 	onReplayEvent: (eventId) => {
 		console.log(`Replay event: ${eventId}`);
 		alert(`Replaying alert for event: ${eventId}`);
@@ -972,7 +1007,7 @@ export const ModerationActionsTest: Story = {
 		stickyDuration: 120000,
 		connectedPlatforms: ["twitch", "youtube", "kick"],
 		onSendMessage: handleSendMessage,
-		moderationCallbacks,
+		moderationCallbacks: alertModerationCallbacks,
 	},
 	parameters: {
 		docs: {

--- a/frontend/src/components/StreamControlsWidget.tsx
+++ b/frontend/src/components/StreamControlsWidget.tsx
@@ -1801,6 +1801,7 @@ interface StreamControlsWidgetProps extends StreamActionCallbacks {
 	stickyDuration?: number;
 	connectedPlatforms?: Platform[];
 	onSendMessage?: (message: string, platforms: Platform[]) => void;
+	moderationCallbacks?: ModerationCallbacks;
 	// Post-stream props
 	summary?: StreamSummary;
 	onStartNewStream?: () => void;
@@ -1837,6 +1838,7 @@ export default function StreamControlsWidget(props: StreamControlsWidgetProps) {
 					stickyDuration={props.stickyDuration}
 					connectedPlatforms={props.connectedPlatforms}
 					onSendMessage={props.onSendMessage}
+					moderationCallbacks={props.moderationCallbacks}
 					onStartPoll={props.onStartPoll}
 					onStartGiveaway={props.onStartGiveaway}
 					onModifyTimers={props.onModifyTimers}

--- a/frontend/src/components/StreamControlsWidget.tsx
+++ b/frontend/src/components/StreamControlsWidget.tsx
@@ -140,6 +140,30 @@ export interface ActivityItem {
 	platform: string;
 	timestamp: Date | string;
 	isImportant?: boolean;
+	// Additional fields needed for moderation actions
+	viewerId?: string;
+	viewerPlatformId?: string;
+}
+
+// Moderation action callbacks
+export interface ModerationCallbacks {
+	onReplayEvent?: (eventId: string) => void;
+	onBanUser?: (
+		userId: string,
+		platform: string,
+		viewerPlatformId: string,
+		username: string,
+		reason?: string,
+	) => void;
+	onTimeoutUser?: (
+		userId: string,
+		platform: string,
+		viewerPlatformId: string,
+		username: string,
+		durationSeconds: number,
+		reason?: string,
+	) => void;
+	onDeleteMessage?: (eventId: string) => void;
 }
 
 // Types for stream summary
@@ -491,12 +515,25 @@ type Platform = (typeof AVAILABLE_PLATFORMS)[number];
 interface ActivityRowProps {
 	item: ActivityItem;
 	isSticky?: boolean;
+	moderationCallbacks?: ModerationCallbacks;
 }
 
 // Row height constant for sticky offset calculations
 const ACTIVITY_ROW_HEIGHT = 52; // px - accounts for padding and content
 
+// Timeout duration presets in seconds
+const TIMEOUT_PRESETS = [
+	{ label: "1m", seconds: 60 },
+	{ label: "5m", seconds: 300 },
+	{ label: "10m", seconds: 600 },
+	{ label: "1h", seconds: 3600 },
+	{ label: "24h", seconds: 86400 },
+] as const;
+
 function ActivityRow(props: ActivityRowProps & { stickyIndex?: number }) {
+	const [isHovered, setIsHovered] = createSignal(false);
+	const [showTimeoutMenu, setShowTimeoutMenu] = createSignal(false);
+
 	// Calculate sticky top offset based on index (for stacking multiple sticky items)
 	const stickyStyle = () => {
 		if (props.isSticky && props.stickyIndex !== undefined) {
@@ -505,16 +542,77 @@ function ActivityRow(props: ActivityRowProps & { stickyIndex?: number }) {
 		return {};
 	};
 
+	// Determine if this row should show moderation actions
+	const showModerationActions = () => {
+		if (!props.moderationCallbacks) return false;
+		if (props.item.type === "chat") {
+			return !!(
+				props.moderationCallbacks.onBanUser ||
+				props.moderationCallbacks.onTimeoutUser ||
+				props.moderationCallbacks.onDeleteMessage
+			);
+		}
+		if (isImportantEvent(props.item.type)) {
+			return !!props.moderationCallbacks.onReplayEvent;
+		}
+		return false;
+	};
+
+	// Handle replay action
+	const handleReplay = (e: MouseEvent) => {
+		e.stopPropagation();
+		props.moderationCallbacks?.onReplayEvent?.(props.item.id);
+	};
+
+	// Handle ban action
+	const handleBan = (e: MouseEvent) => {
+		e.stopPropagation();
+		if (props.item.viewerId && props.item.viewerPlatformId) {
+			props.moderationCallbacks?.onBanUser?.(
+				props.item.viewerId,
+				props.item.platform,
+				props.item.viewerPlatformId,
+				props.item.username,
+			);
+		}
+	};
+
+	// Handle timeout action
+	const handleTimeout = (e: MouseEvent, seconds: number) => {
+		e.stopPropagation();
+		setShowTimeoutMenu(false);
+		if (props.item.viewerId && props.item.viewerPlatformId) {
+			props.moderationCallbacks?.onTimeoutUser?.(
+				props.item.viewerId,
+				props.item.platform,
+				props.item.viewerPlatformId,
+				props.item.username,
+				seconds,
+			);
+		}
+	};
+
+	// Handle delete action
+	const handleDelete = (e: MouseEvent) => {
+		e.stopPropagation();
+		props.moderationCallbacks?.onDeleteMessage?.(props.item.id);
+	};
+
 	return (
 		<div
-			class={`flex items-center gap-2 rounded px-2 py-2 transition-colors hover:bg-gray-50 ${
+			class={`group relative flex items-center gap-2 rounded px-2 py-2 transition-colors hover:bg-gray-50 ${
 				props.isSticky
 					? "sticky z-10 border-amber-200 border-b bg-amber-50 shadow-sm"
 					: isImportantEvent(props.item.type)
 						? "bg-gray-50/50"
 						: ""
 			}`}
-			style={stickyStyle()}>
+			style={stickyStyle()}
+			onMouseEnter={() => setIsHovered(true)}
+			onMouseLeave={() => {
+				setIsHovered(false);
+				setShowTimeoutMenu(false);
+			}}>
 			{/* Platform badge */}
 			<span
 				class={`flex h-6 w-6 shrink-0 items-center justify-center rounded text-white text-xs ${PLATFORM_COLORS[props.item.platform] || "bg-gray-500"}`}>
@@ -548,6 +646,86 @@ function ActivityRow(props: ActivityRowProps & { stickyIndex?: number }) {
 					</div>
 				</Show>
 			</div>
+
+			{/* Hover Actions - Icon-only buttons with tooltips */}
+			<Show when={isHovered() && showModerationActions()}>
+				<div class="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 rounded bg-white/95 px-1 py-0.5 shadow-sm ring-1 ring-gray-200">
+					{/* Replay button for important events */}
+					<Show
+						when={
+							isImportantEvent(props.item.type) &&
+							props.moderationCallbacks?.onReplayEvent
+						}>
+						<button
+							type="button"
+							class="rounded p-1 text-purple-600 transition-colors hover:bg-purple-50"
+							onClick={handleReplay}
+							title="Replay alert"
+							data-testid="replay-button">
+							<span class="text-xs">&#x21bb;</span>
+						</button>
+					</Show>
+
+					{/* Chat moderation actions */}
+					<Show when={props.item.type === "chat"}>
+						{/* Delete message button */}
+						<Show when={props.moderationCallbacks?.onDeleteMessage}>
+							<button
+								type="button"
+								class="rounded p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+								onClick={handleDelete}
+								title="Delete message"
+								data-testid="delete-button">
+								<span class="text-xs">&#x2715;</span>
+							</button>
+						</Show>
+
+						{/* Timeout button with dropdown */}
+						<Show when={props.moderationCallbacks?.onTimeoutUser}>
+							<div class="relative">
+								<button
+									type="button"
+									class="rounded p-1 text-amber-600 transition-colors hover:bg-amber-50"
+									onClick={(e) => {
+										e.stopPropagation();
+										setShowTimeoutMenu(!showTimeoutMenu());
+									}}
+									title="Timeout user"
+									data-testid="timeout-button">
+									<span class="text-xs">&#x23F1;</span>
+								</button>
+								<Show when={showTimeoutMenu()}>
+									<div class="absolute top-full right-0 z-20 mt-1 min-w-[60px] rounded border border-gray-200 bg-white py-0.5 shadow-lg">
+										<For each={TIMEOUT_PRESETS}>
+											{(preset) => (
+												<button
+													type="button"
+													class="block w-full px-2 py-0.5 text-left text-gray-700 text-xs transition-colors hover:bg-amber-50"
+													onClick={(e) => handleTimeout(e, preset.seconds)}
+													data-testid={`timeout-${preset.label}`}>
+													{preset.label}
+												</button>
+											)}
+										</For>
+									</div>
+								</Show>
+							</div>
+						</Show>
+
+						{/* Ban button */}
+						<Show when={props.moderationCallbacks?.onBanUser}>
+							<button
+								type="button"
+								class="rounded p-1 text-red-600 transition-colors hover:bg-red-50"
+								onClick={handleBan}
+								title="Ban user"
+								data-testid="ban-button">
+								<span class="text-xs">&#x26D4;</span>
+							</button>
+						</Show>
+					</Show>
+				</div>
+			</Show>
 		</div>
 	);
 }
@@ -673,6 +851,7 @@ interface LiveStreamControlCenterProps extends StreamActionCallbacks {
 	stickyDuration?: number; // how long important events stay sticky (ms)
 	connectedPlatforms?: Platform[]; // platforms the user is connected to
 	onSendMessage?: (message: string, platforms: Platform[]) => void;
+	moderationCallbacks?: ModerationCallbacks;
 }
 
 // All available activity types for filtering
@@ -1260,6 +1439,7 @@ export function LiveStreamControlCenter(props: LiveStreamControlCenterProps) {
 										item={item}
 										isSticky={isSticky()}
 										stickyIndex={stickyIndex()}
+										moderationCallbacks={props.moderationCallbacks}
 									/>
 								);
 							}}

--- a/frontend/src/routes/dashboard/admin/notifications.tsx
+++ b/frontend/src/routes/dashboard/admin/notifications.tsx
@@ -368,7 +368,10 @@ export default function AdminNotifications() {
 									</tbody>
 								</table>
 
-								<Show when={!notificationsLoading() && notifications().length === 0}>
+								<Show
+									when={
+										!notificationsLoading() && notifications().length === 0
+									}>
 									<div class="py-12 text-center">
 										<svg
 											aria-hidden="true"
@@ -516,7 +519,9 @@ export default function AdminNotifications() {
 																</span>
 																<button
 																	type="button"
-																	onClick={() => removeLocalization(loc().locale)}
+																	onClick={() =>
+																		removeLocalization(loc().locale)
+																	}
 																	class="text-red-500 hover:text-red-700"
 																	title="Remove translation">
 																	<svg


### PR DESCRIPTION
## Summary
- Add "Replay" option for important events (donations, subscriptions, raids, cheers) that appears on hover
- Add "Ban", "Timeout", and "Delete" options for chat messages that appear on hover
- Add timeout duration presets (1m, 5m, 10m, 1h, 24h) via dropdown menu
- Add new `ModerationCallbacks` interface for handling moderation actions
- Update `ActivityItem` interface with `viewerId` and `viewerPlatformId` fields for moderation

## Test plan
- [x] Hover over chat messages to see Ban, Timeout, and Delete buttons
- [x] Click Timeout button to see duration dropdown menu (1m, 5m, 10m, 1h, 24h)
- [x] Hover over important events (donations, subscriptions, raids) to see Replay button
- [x] Verify buttons trigger the callback functions
- [x] Tested with Playwright in headless mode via Storybook ModerationActionsTest story

🤖 Generated with [Claude Code](https://claude.com/claude-code)