### PR TITLE
Add Poll and Giveaway creation forms to Stream Actions panel

### DIFF
--- a/frontend/src/components/StreamControlsWidget.stories.tsx
+++ b/frontend/src/components/StreamControlsWidget.stories.tsx
@@ -283,8 +283,23 @@ const handleSendMessage = (message: string, platforms: Platform[]) => {
 };
 
 // Stream action handlers for Storybook
-const handleStartPoll = () => console.log("Start poll clicked");
-const handleStartGiveaway = () => console.log("Start giveaway clicked");
+const handleStartPoll = (data: {
+	question: string;
+	option1: string;
+	option2: string;
+	option3: string;
+	option4: string;
+	duration: number;
+	allowMultipleVotes: boolean;
+}) => console.log("Start poll with data:", data);
+const handleStartGiveaway = (data: {
+	title: string;
+	description: string;
+	keyword: string;
+	duration: number;
+	subscriberMultiplier: number;
+	subscriberOnly: boolean;
+}) => console.log("Start giveaway with data:", data);
 const handleModifyTimers = () => console.log("Modify timers clicked");
 const handleChangeStreamSettings = () =>
 	console.log("Change stream settings clicked");


### PR DESCRIPTION
## Summary
- Adds Poll and Giveaway action buttons to the Stream Actions panel in the live stream control center
- Clicking Poll/Giveaway opens interactive creation forms using SchemaForm component
- Forms include validation (Start button disabled until required fields filled)
- Poll form: question, 4 options (2 required), duration slider, allow multiple votes toggle
- Giveaway form: title, description, entry keyword, duration, subscriber multiplier, subscribers-only toggle
- Submitting forms calls callback with form data and returns to Actions view

## Test plan
- [x] Verified Poll form renders with all fields
- [x] Verified Start Poll button is disabled until question + 2 options filled
- [x] Verified clicking Start Poll logs form data and returns to Actions
- [x] Verified Giveaway form renders with all fields and defaults
- [x] Verified Start Giveaway button works and logs form data
- [x] Tested with headless Playwright in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)