### PR TITLE
SchemaForm enhancements: custom option labels and i18n support

### DIFF
--- a/frontend/src/lib/schema-form/SchemaForm.stories.tsx
+++ b/frontend/src/lib/schema-form/SchemaForm.stories.tsx
@@ -10,6 +10,8 @@ import {
 	allFieldTypesSchema,
 	chatConfigMeta,
 	chatConfigSchema,
+	customOptionsMeta,
+	customOptionsSchema,
 	timerConfigMeta,
 	timerConfigSchema,
 } from "./widget-schemas";
@@ -354,6 +356,50 @@ export const NoMetadata: Story = {
 				<div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
 					<h3 class="mb-2 font-medium text-gray-700 text-sm">
 						Current Values:
+					</h3>
+					<pre class="text-gray-600 text-xs">
+						{JSON.stringify(values(), null, 2)}
+					</pre>
+				</div>
+			</div>
+		);
+	},
+};
+
+/**
+ * Demonstrates custom option labels for select fields.
+ * This is useful when enum values don't match desired display labels,
+ * such as numeric duration values that should display as "7 days", "30 days", etc.
+ */
+export const CustomSelectOptions: Story = {
+	render: () => {
+		const [values, setValues] = createSignal({
+			duration: "30" as const,
+			priority: "medium" as const,
+		});
+
+		return (
+			<div class="space-y-6">
+				<div>
+					<h2 class="mb-1 font-semibold text-gray-900 text-lg">
+						Custom Select Options
+					</h2>
+					<p class="mb-4 text-gray-500 text-sm">
+						Select fields with custom option labels via the{" "}
+						<code class="rounded bg-gray-100 px-1">options</code> metadata
+					</p>
+					<SchemaForm
+						schema={customOptionsSchema}
+						meta={customOptionsMeta}
+						values={values()}
+						onChange={(field, value) => {
+							setValues((prev) => ({ ...prev, [field]: value }));
+						}}
+					/>
+				</div>
+				<div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+					<h3 class="mb-2 font-medium text-gray-700 text-sm">
+						Current Values (raw enum values):
 					</h3>
 					<pre class="text-gray-600 text-xs">
 						{JSON.stringify(values(), null, 2)}

--- a/frontend/src/lib/schema-form/SchemaForm.stories.tsx
+++ b/frontend/src/lib/schema-form/SchemaForm.stories.tsx
@@ -12,9 +12,12 @@ import {
 	chatConfigSchema,
 	customOptionsMeta,
 	customOptionsSchema,
+	i18nDemoMeta,
+	i18nDemoSchema,
 	timerConfigMeta,
 	timerConfigSchema,
 } from "./widget-schemas";
+import type { TranslationFunction } from "./types";
 
 /**
  * SchemaForm automatically generates form UI from Zod schemas.
@@ -400,6 +403,147 @@ export const CustomSelectOptions: Story = {
 				<div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
 					<h3 class="mb-2 font-medium text-gray-700 text-sm">
 						Current Values (raw enum values):
+					</h3>
+					<pre class="text-gray-600 text-xs">
+						{JSON.stringify(values(), null, 2)}
+					</pre>
+				</div>
+			</div>
+		);
+	},
+};
+
+// Mock translations for demo purposes
+const mockTranslations: Record<string, Record<string, string>> = {
+	en: {
+		"demo.displayName": "Display Name",
+		"demo.displayNamePlaceholder": "Enter your display name",
+		"demo.displayNameDescription": "This name will be shown to other users",
+		"demo.theme": "Theme",
+		"demo.themeDescription": "Choose your preferred color theme",
+		"demo.themeLight": "Light Mode",
+		"demo.themeDark": "Dark Mode",
+		"demo.themeSystem": "System Default",
+		"demo.emailNotifications": "Email Notifications",
+		"demo.emailNotificationsDescription":
+			"Receive email updates about your account",
+	},
+	de: {
+		"demo.displayName": "Anzeigename",
+		"demo.displayNamePlaceholder": "Gib deinen Anzeigenamen ein",
+		"demo.displayNameDescription":
+			"Dieser Name wird anderen Benutzern angezeigt",
+		"demo.theme": "Design",
+		"demo.themeDescription": "Wähle dein bevorzugtes Farbschema",
+		"demo.themeLight": "Hell",
+		"demo.themeDark": "Dunkel",
+		"demo.themeSystem": "Systemstandard",
+		"demo.emailNotifications": "E-Mail-Benachrichtigungen",
+		"demo.emailNotificationsDescription":
+			"E-Mail-Updates zu deinem Konto erhalten",
+	},
+	pl: {
+		"demo.displayName": "Nazwa wyświetlana",
+		"demo.displayNamePlaceholder": "Wprowadź swoją nazwę",
+		"demo.displayNameDescription":
+			"Ta nazwa będzie widoczna dla innych użytkowników",
+		"demo.theme": "Motyw",
+		"demo.themeDescription": "Wybierz preferowany motyw kolorystyczny",
+		"demo.themeLight": "Jasny",
+		"demo.themeDark": "Ciemny",
+		"demo.themeSystem": "Systemowy",
+		"demo.emailNotifications": "Powiadomienia e-mail",
+		"demo.emailNotificationsDescription":
+			"Otrzymuj aktualizacje e-mail o swoim koncie",
+	},
+	es: {
+		"demo.displayName": "Nombre para mostrar",
+		"demo.displayNamePlaceholder": "Ingresa tu nombre para mostrar",
+		"demo.displayNameDescription":
+			"Este nombre se mostrará a otros usuarios",
+		"demo.theme": "Tema",
+		"demo.themeDescription": "Elige tu tema de colores preferido",
+		"demo.themeLight": "Claro",
+		"demo.themeDark": "Oscuro",
+		"demo.themeSystem": "Sistema",
+		"demo.emailNotifications": "Notificaciones por email",
+		"demo.emailNotificationsDescription":
+			"Recibe actualizaciones por email sobre tu cuenta",
+	},
+};
+
+/**
+ * Demonstrates i18n (internationalization) support.
+ * Pass a translation function to SchemaForm to localize labels, descriptions, and options.
+ * The metadata uses i18n keys (labelKey, descriptionKey, optionKeys) instead of static strings.
+ */
+export const I18nLocalization: Story = {
+	render: () => {
+		const [values, setValues] = createSignal({
+			displayName: "",
+			theme: "system" as const,
+			emailNotifications: true,
+		});
+
+		const [locale, setLocale] = createSignal<"en" | "de" | "pl" | "es">("en");
+
+		// Mock translation function that looks up keys in our mock translations
+		const t: TranslationFunction = (key) => {
+			return mockTranslations[locale()]?.[key] ?? key;
+		};
+
+		return (
+			<div class="space-y-6">
+				<div>
+					<h2 class="mb-1 font-semibold text-gray-900 text-lg">
+						i18n Localization
+					</h2>
+					<p class="mb-4 text-gray-500 text-sm">
+						Form with localized labels via the{" "}
+						<code class="rounded bg-gray-100 px-1">t</code> translation function
+					</p>
+
+					{/* Language Switcher */}
+					<div class="mb-4 flex gap-2">
+						<button
+							type="button"
+							onClick={() => setLocale("en")}
+							class={`rounded px-3 py-1 text-sm ${locale() === "en" ? "bg-purple-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}>
+							English
+						</button>
+						<button
+							type="button"
+							onClick={() => setLocale("de")}
+							class={`rounded px-3 py-1 text-sm ${locale() === "de" ? "bg-purple-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}>
+							Deutsch
+						</button>
+						<button
+							type="button"
+							onClick={() => setLocale("pl")}
+							class={`rounded px-3 py-1 text-sm ${locale() === "pl" ? "bg-purple-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}>
+							Polski
+						</button>
+						<button
+							type="button"
+							onClick={() => setLocale("es")}
+							class={`rounded px-3 py-1 text-sm ${locale() === "es" ? "bg-purple-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}>
+							Español
+						</button>
+					</div>
+
+					<SchemaForm
+						schema={i18nDemoSchema}
+						meta={i18nDemoMeta}
+						values={values()}
+						onChange={(field, value) => {
+							setValues((prev) => ({ ...prev, [field]: value }));
+						}}
+						t={t}
+					/>
+				</div>
+				<div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+					<h3 class="mb-2 font-medium text-gray-700 text-sm">
+						Current Values:
 					</h3>
 					<pre class="text-gray-600 text-xs">
 						{JSON.stringify(values(), null, 2)}

--- a/frontend/src/lib/schema-form/fields/SelectField.tsx
+++ b/frontend/src/lib/schema-form/fields/SelectField.tsx
@@ -22,6 +22,17 @@ function enumValueToLabel(value: string): string {
 		.join(" ");
 }
 
+/**
+ * Get the display label for an option value.
+ * Uses custom options from metadata if provided, otherwise auto-generates from value.
+ */
+function getOptionLabel(value: string, customOptions?: Record<string, string>): string {
+	if (customOptions && value in customOptions) {
+		return customOptions[value];
+	}
+	return enumValueToLabel(value);
+}
+
 export const SelectField: Component<SelectFieldProps> = (props) => {
 	return (
 		<Select
@@ -31,7 +42,11 @@ export const SelectField: Component<SelectFieldProps> = (props) => {
 			onChange={(e) => props.onChange(e.currentTarget.value)}
 			value={props.value ?? ""}>
 			<For each={props.field.enumValues ?? []}>
-				{(option) => <option value={option}>{enumValueToLabel(option)}</option>}
+				{(option) => (
+					<option value={option}>
+						{getOptionLabel(option, props.field.meta.options)}
+					</option>
+				)}
 			</For>
 		</Select>
 	);

--- a/frontend/src/lib/schema-form/index.ts
+++ b/frontend/src/lib/schema-form/index.ts
@@ -73,13 +73,35 @@
  * ## Metadata Options
  *
  * - `label`: Human-readable field label (default: derived from field name)
+ * - `labelKey`: i18n key for label (used when `t` prop is provided)
  * - `inputType`: Override auto-detected input type
  * - `description`: Help text shown below the field
+ * - `descriptionKey`: i18n key for description
  * - `placeholder`: Placeholder text (for text/textarea)
+ * - `placeholderKey`: i18n key for placeholder
  * - `unit`: Unit label (for number/slider, e.g., "px", "%")
  * - `step`: Step increment (for number/slider)
  * - `group`: Group fields into sections
+ * - `groupKey`: i18n key for group header
  * - `hidden`: Hide field from form
+ * - `options`: Custom labels for select options (maps enum value to display label)
+ * - `optionKeys`: i18n keys for select options
+ *
+ * ## i18n Support
+ *
+ * Pass the `t` translation function to enable localization:
+ * ```tsx
+ * import { useTranslation } from "~/i18n";
+ *
+ * const { t } = useTranslation();
+ *
+ * const meta = {
+ *   label: { labelKey: "settings.timerLabel" },
+ *   fontSize: { labelKey: "settings.fontSize", descriptionKey: "settings.fontSizeHelp" },
+ * };
+ *
+ * <SchemaForm schema={schema} meta={meta} values={values()} onChange={...} t={t} />
+ * ```
  *
  * ## Field Order
  *
@@ -107,4 +129,5 @@ export type {
 	IntrospectedField,
 	IntrospectedSchema,
 	SchemaFormProps,
+	TranslationFunction,
 } from "./types";

--- a/frontend/src/lib/schema-form/types.ts
+++ b/frontend/src/lib/schema-form/types.ts
@@ -32,22 +32,32 @@ export type InputType =
 export interface FieldMeta {
 	/** Human-readable label (default: derived from field name) */
 	label?: string;
+	/** i18n key for label - when provided with a translation function, used instead of label */
+	labelKey?: string;
 	/** Override the auto-detected input type */
 	inputType?: InputType;
 	/** Description/helper text shown below the field */
 	description?: string;
+	/** i18n key for description - when provided with a translation function, used instead of description */
+	descriptionKey?: string;
 	/** Group fields together under a section header */
 	group?: string;
+	/** i18n key for group header - when provided with a translation function, used instead of group */
+	groupKey?: string;
 	/** Hide this field in the form */
 	hidden?: boolean;
 	/** Placeholder text (for text/textarea fields) */
 	placeholder?: string;
+	/** i18n key for placeholder - when provided with a translation function, used instead of placeholder */
+	placeholderKey?: string;
 	/** Unit label (for number/slider fields, e.g., "px", "s", "%") */
 	unit?: string;
 	/** Step increment (for number/slider fields) */
 	step?: number;
 	/** Custom labels for select options (maps enum value to display label) */
 	options?: Record<string, string>;
+	/** i18n keys for select options (maps enum value to i18n key) */
+	optionKeys?: Record<string, string>;
 }
 
 /**
@@ -110,6 +120,14 @@ export interface IntrospectedSchema {
 }
 
 /**
+ * Translation function type - compatible with useTranslation().t
+ */
+export type TranslationFunction = (
+	key: string,
+	params?: Record<string, string | number>,
+) => string;
+
+/**
  * Props for the auto-generated form component
  */
 export interface SchemaFormProps<T extends z.ZodRawShape> {
@@ -128,4 +146,6 @@ export interface SchemaFormProps<T extends z.ZodRawShape> {
 	class?: string;
 	/** Whether the form is disabled */
 	disabled?: boolean;
+	/** Optional translation function for i18n support. When provided, fields can use i18n keys (labelKey, descriptionKey, etc.) */
+	t?: TranslationFunction;
 }

--- a/frontend/src/lib/schema-form/types.ts
+++ b/frontend/src/lib/schema-form/types.ts
@@ -46,6 +46,8 @@ export interface FieldMeta {
 	unit?: string;
 	/** Step increment (for number/slider fields) */
 	step?: number;
+	/** Custom labels for select options (maps enum value to display label) */
+	options?: Record<string, string>;
 }
 
 /**

--- a/frontend/src/lib/schema-form/widget-schemas.ts
+++ b/frontend/src/lib/schema-form/widget-schemas.ts
@@ -351,3 +351,42 @@ export const customOptionsMeta: FormMeta<typeof customOptionsSchema.shape> = {
 		},
 	},
 };
+
+// =============================================================================
+// i18n Demo (for testing localization support)
+// =============================================================================
+
+/**
+ * Demo schema for i18n support
+ */
+export const i18nDemoSchema = z.object({
+	displayName: z.string().default(""),
+	theme: z.enum(["light", "dark", "system"]).default("system"),
+	emailNotifications: z.boolean().default(true),
+});
+
+export type I18nDemoConfig = z.infer<typeof i18nDemoSchema>;
+
+/**
+ * Demo metadata with i18n keys - labels/descriptions are resolved via translation function
+ */
+export const i18nDemoMeta: FormMeta<typeof i18nDemoSchema.shape> = {
+	displayName: {
+		labelKey: "demo.displayName",
+		placeholderKey: "demo.displayNamePlaceholder",
+		descriptionKey: "demo.displayNameDescription",
+	},
+	theme: {
+		labelKey: "demo.theme",
+		descriptionKey: "demo.themeDescription",
+		optionKeys: {
+			light: "demo.themeLight",
+			dark: "demo.themeDark",
+			system: "demo.themeSystem",
+		},
+	},
+	emailNotifications: {
+		labelKey: "demo.emailNotifications",
+		descriptionKey: "demo.emailNotificationsDescription",
+	},
+};

--- a/frontend/src/lib/schema-form/widget-schemas.ts
+++ b/frontend/src/lib/schema-form/widget-schemas.ts
@@ -311,3 +311,43 @@ export const allFieldTypesMeta: FormMeta<typeof allFieldTypesSchema.shape> = {
 	enabled: { label: "Enabled", description: "Toggle this feature on/off" },
 	size: { label: "Size" },
 };
+
+// =============================================================================
+// Custom Select Options (for testing custom option labels)
+// =============================================================================
+
+/**
+ * Demo schema showing custom option labels for select fields
+ */
+export const customOptionsSchema = z.object({
+	duration: z.enum(["7", "30", "90", "180", "365"]).default("30"),
+	priority: z.enum(["low", "medium", "high", "critical"]).default("medium"),
+});
+
+export type CustomOptionsConfig = z.infer<typeof customOptionsSchema>;
+
+/**
+ * Demo metadata with custom option labels
+ */
+export const customOptionsMeta: FormMeta<typeof customOptionsSchema.shape> = {
+	duration: {
+		label: "Duration",
+		description: "Select how long to apply the setting",
+		options: {
+			"7": "7 days",
+			"30": "30 days (1 month)",
+			"90": "90 days (3 months)",
+			"180": "180 days (6 months)",
+			"365": "365 days (1 year)",
+		},
+	},
+	priority: {
+		label: "Priority Level",
+		options: {
+			low: "Low Priority",
+			medium: "Medium Priority",
+			high: "High Priority",
+			critical: "Critical - Urgent!",
+		},
+	},
+};


### PR DESCRIPTION
## Summary
- Migrates the admin Grant PRO modal form to use the SchemaForm component
- Adds `options` metadata field for custom select option labels
- **NEW: Adds i18n localization support to SchemaForm**

## Changes

### i18n Localization Support (NEW)
- Added `labelKey`, `descriptionKey`, `placeholderKey`, `groupKey`, and `optionKeys` to FieldMeta for i18n keys
- Added `TranslationFunction` type compatible with `useTranslation().t`
- Added optional `t` prop to SchemaForm to enable translations
- Fields can now use i18n keys that get resolved via the translation function
- Added I18nLocalization story demonstrating language switching (EN, DE, PL, ES)

### Custom Select Options
- Added `options?: Record<string, string>` to `FieldMeta` type
- SelectField now uses custom labels when `options` metadata is provided
- Falls back to auto-generated labels when no custom options are specified

### Grant PRO Modal Migration
The admin users page Grant PRO modal now uses SchemaForm with:
- Duration select with custom labels ("7 days", "30 days (1 month)", etc.)
- Reason textarea with placeholder and description

## Usage Example

```tsx
import { useTranslation } from "~/i18n";
import { SchemaForm } from "~/lib/schema-form";

const meta = {
  displayName: { 
    labelKey: "settings.displayName",
    placeholderKey: "settings.displayNamePlaceholder" 
  },
  theme: { 
    labelKey: "settings.theme",
    optionKeys: {
      light: "settings.themeLight",
      dark: "settings.themeDark",
    }
  },
};

const { t } = useTranslation();

<SchemaForm schema={schema} meta={meta} values={values()} onChange={...} t={t} />
```

## Test plan
- [x] Build succeeds
- [x] Verified SchemaForm stories work correctly in Storybook
- [x] Tested i18n story with language switching (EN, DE, PL, ES) via Playwright
- [x] Labels, descriptions, placeholders, and select options all translate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)