### PR TITLE
Fix widget settings animation type not populated correctly

### DIFF
--- a/frontend/src/lib/schema-form/fields/SelectField.tsx
+++ b/frontend/src/lib/schema-form/fields/SelectField.tsx
@@ -46,7 +46,7 @@ export const SelectField: Component<SelectFieldProps> = (props) => {
 			value={props.value ?? ""}>
 			<For each={props.field.enumValues ?? []}>
 				{(option) => (
-					<option value={option}>
+					<option selected={props.value === option} value={option}>
 						{getOptionLabel(option, props.field.meta.options)}
 					</option>
 				)}


### PR DESCRIPTION
## Summary

- Fixed SelectField not displaying the correct value when data is loaded asynchronously from Electric SQL
- The issue was that SolidJS's select element value prop doesn't update properly when options are rendered after the value is set
- Added `selected` attribute directly on option elements to ensure correct display regardless of async timing

This fixes the bug where the animation type dropdown showed "slide" (first option) instead of the actual saved value like "bounce", even though the preview was using the correct animation.

## Technical Details

In SolidJS, unlike React, the `value` prop on `<select>` doesn't automatically sync when options are loaded asynchronously. The [standard solution](https://github.com/solidjs/solid/issues/2241) is to set the `selected` attribute on each `<option>` element.

## Test plan

- [ ] Navigate to Widget Settings page (e.g., Alertbox)
- [ ] Change Animation Type to "Bounce" and save
- [ ] Refresh the page
- [ ] Verify Animation Type dropdown shows "Bounce" (not "Slide")
- [ ] Verify preview uses bounce animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)