### PR TITLE
Localize stream page placeholder strings

### DIFF
--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -124,6 +124,12 @@ export const dict: Dictionary = {
 		signInToAccess: "Bitte melde dich an, um aufs Dashboard zuzugreifen.",
 	},
 
+	// Stream page
+	stream: {
+		streamTitlePlaceholder: "Titel deines Streams...",
+		streamDescriptionPlaceholder: "Beschreibe deinen Stream...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Stream-Statistiken",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -122,6 +122,12 @@ export const dict = {
 		signInToAccess: "Please sign in to access the dashboard.",
 	},
 
+	// Stream page
+	stream: {
+		streamTitlePlaceholder: "Enter your stream title...",
+		streamDescriptionPlaceholder: "Describe your stream...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Stream Analytics",

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -124,6 +124,12 @@ export const dict: Dictionary = {
 		signInToAccess: "Inicia sesión para acceder al panel.",
 	},
 
+	// Stream page
+	stream: {
+		streamTitlePlaceholder: "Ingresa el título del stream...",
+		streamDescriptionPlaceholder: "Describe tu stream...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Estadísticas de streams",

--- a/frontend/src/i18n/locales/pl.ts
+++ b/frontend/src/i18n/locales/pl.ts
@@ -124,6 +124,12 @@ export const dict: Dictionary = {
 		signInToAccess: "Zaloguj się, aby uzyskać dostęp do panelu.",
 	},
 
+	// Stream page
+	stream: {
+		streamTitlePlaceholder: "Wpisz tytuł streama...",
+		streamDescriptionPlaceholder: "Opisz swój stream...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Statystyki streamów",

--- a/frontend/src/routes/dashboard/stream.tsx
+++ b/frontend/src/routes/dashboard/stream.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from "~/components/ui";
 import Badge from "~/components/ui/Badge";
 import Button from "~/components/ui/Button";
 import Card from "~/components/ui/Card";
+import { useTranslation } from "~/i18n";
 import { getLoginUrl, useCurrentUser } from "~/lib/auth";
 import { apiRoutes } from "~/lib/constants";
 import { useStreamingAccounts } from "~/lib/useElectric";
@@ -118,6 +119,7 @@ type StreamKeyData = {
 };
 
 export default function Stream() {
+	const { t } = useTranslation();
 	const { user, isLoading } = useCurrentUser();
 	const streamingAccounts = useStreamingAccounts(() => user()?.id);
 	const [streamStatus, setStreamStatus] = createSignal<StreamStatus>("offline");
@@ -352,7 +354,7 @@ export default function Stream() {
 													title: e.currentTarget.value,
 												}))
 											}
-											placeholder="Enter your stream title..."
+											placeholder={t("stream.streamTitlePlaceholder")}
 											type="text"
 											value={streamMetadata().title}
 										/>
@@ -369,7 +371,7 @@ export default function Stream() {
 													description: e.currentTarget.value,
 												}))
 											}
-											placeholder="Describe your stream..."
+											placeholder={t("stream.streamDescriptionPlaceholder")}
 											rows="3"
 											value={streamMetadata().description}
 										/>


### PR DESCRIPTION
## Summary
- Add translation keys for hardcoded placeholder strings in dashboard stream page
- Update `stream.tsx` to use `t()` function for placeholders
- Add translations to all 4 locale files (en, de, pl, es)

### Changes
- `stream.streamTitlePlaceholder`: "Enter your stream title..." 
- `stream.streamDescriptionPlaceholder`: "Describe your stream..."

## Test plan
- [x] All 4 locale files updated with new keys
- [x] Component uses translation keys via `t()` function
- [x] `bun test locales.test.ts` passes
- [x] TypeScript type checking passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)