### PR TITLE
Localize hardcoded strings in admin notifications page

### DIFF
--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -518,6 +518,12 @@ export const dict: Dictionary = {
 			"Wir freuen uns über Feedback! Kontaktiere uns mit Fehlerberichten oder Funktionsvorschlägen. Du kannst auch unserer Discord-Community beitreten und Ideen diskutieren.",
 	},
 
+	// Admin pages
+	admin: {
+		enterUserUuid: "Benutzer-UUID eingeben",
+		enterNotificationMessage: "Benachrichtigungstext eingeben...",
+	},
+
 	// Contact page
 	contact: {
 		title: "Kontakt",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -529,6 +529,12 @@ export const dict = {
 			"We love hearing from our users! Please contact us with bug reports or feature requests. You can also join our Discord community to discuss ideas with other users.",
 	},
 
+	// Admin pages
+	admin: {
+		enterUserUuid: "Enter user UUID",
+		enterNotificationMessage: "Enter notification message...",
+	},
+
 	// Contact page
 	contact: {
 		title: "Contact Us",

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -521,6 +521,12 @@ export const dict: Dictionary = {
 			"¡Nos encanta recibir feedback! Contáctanos con reportes de errores o sugerencias. También puedes unirte a nuestro Discord para discutir ideas con otros usuarios.",
 	},
 
+	// Admin pages
+	admin: {
+		enterUserUuid: "Ingresa el UUID del usuario",
+		enterNotificationMessage: "Ingresa el mensaje de notificación...",
+	},
+
 	// Contact page
 	contact: {
 		title: "Contacto",

--- a/frontend/src/i18n/locales/pl.ts
+++ b/frontend/src/i18n/locales/pl.ts
@@ -515,6 +515,12 @@ export const dict: Dictionary = {
 			"Chętnie słuchamy użytkowników! Napisz do nas z informacją o błędzie lub propozycją nowej funkcji. Możesz też dołączyć do naszego Discorda i podzielić się pomysłami z innymi.",
 	},
 
+	// Admin pages
+	admin: {
+		enterUserUuid: "Wpisz UUID użytkownika",
+		enterNotificationMessage: "Wpisz treść powiadomienia...",
+	},
+
 	// Contact page
 	contact: {
 		title: "Kontakt",

--- a/frontend/src/routes/dashboard/admin/notifications.tsx
+++ b/frontend/src/routes/dashboard/admin/notifications.tsx
@@ -5,7 +5,12 @@ import Badge from "~/components/ui/Badge";
 import Button from "~/components/ui/Button";
 import Card from "~/components/ui/Card";
 import Input, { Select, Textarea } from "~/components/ui/Input";
-import { LOCALE_NAMES, type Locale, SUPPORTED_LOCALES } from "~/i18n";
+import {
+	LOCALE_NAMES,
+	type Locale,
+	SUPPORTED_LOCALES,
+	useTranslation,
+} from "~/i18n";
 import { useCurrentUser } from "~/lib/auth";
 import { type Notification, useGlobalNotifications } from "~/lib/useElectric";
 import { createNotification, deleteNotification } from "~/sdk/ash_rpc";
@@ -17,6 +22,7 @@ type LocalizationEntry = {
 };
 
 export default function AdminNotifications() {
+	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const { user: currentUser, isLoading: authLoading } = useCurrentUser();
 	const { data: notifications, isLoading: notificationsLoading } =
@@ -461,7 +467,7 @@ export default function AdminNotifications() {
 											<Input
 												id="target-user-id"
 												onInput={(e) => setTargetUserId(e.currentTarget.value)}
-												placeholder="Enter user UUID"
+												placeholder={t("admin.enterUserUuid")}
 												type="text"
 												value={targetUserId()}
 											/>
@@ -480,7 +486,7 @@ export default function AdminNotifications() {
 											onInput={(e) =>
 												setNotificationContent(e.currentTarget.value)
 											}
-											placeholder="Enter notification message..."
+											placeholder={t("admin.enterNotificationMessage")}
 											rows={3}
 											value={notificationContent()}
 										/>


### PR DESCRIPTION
## Summary
- Added `admin` section to all 4 locale files (en, de, pl, es) with new translation keys
- Updated admin notifications page to use `t()` function for placeholder text
- Replaced hardcoded "Enter user UUID" and "Enter notification message..." with localized strings

## Test plan
- [x] All locale tests pass (`bun test src/i18n/locales/locales.test.ts`)
- [x] Pre-commit hooks pass (frontend-format, frontend-typecheck)
- [ ] Manually verify placeholder text appears correctly in admin notifications page for each language

🤖 Generated with [Claude Code](https://claude.com/claude-code)