### PR TITLE
Refactor settings.tsx into separate section components

### DIFF
--- a/frontend/src/components/settings/AvatarUploadSection.tsx
+++ b/frontend/src/components/settings/AvatarUploadSection.tsx
@@ -1,0 +1,186 @@
+import { Show, createSignal } from "solid-js";
+import { useTranslation } from "~/i18n";
+import {
+	confirmFileUpload,
+	requestFileUpload,
+	updateAvatar,
+} from "~/sdk/ash_rpc";
+
+interface AvatarUploadSectionProps {
+	userId: string;
+	currentAvatarUrl: string | null | undefined;
+	displayName: string | null | undefined;
+}
+
+export default function AvatarUploadSection(props: AvatarUploadSectionProps) {
+	const { t } = useTranslation();
+	const [isUploading, setIsUploading] = createSignal(false);
+	const [uploadError, setUploadError] = createSignal<string | null>(null);
+	const [uploadSuccess, setUploadSuccess] = createSignal(false);
+	let fileInputRef: HTMLInputElement | undefined;
+
+	const handleAvatarUpload = async (file: File) => {
+		setIsUploading(true);
+		setUploadError(null);
+		setUploadSuccess(false);
+
+		try {
+			const requestResult = await requestFileUpload({
+				input: {
+					filename: file.name,
+					contentType: file.type,
+					fileType: "avatar",
+					estimatedSize: file.size,
+				},
+				fields: ["id", "uploadUrl", "uploadHeaders", "maxSize"],
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!requestResult.success) {
+				throw new Error(
+					requestResult.errors?.[0]?.message || "Failed to get upload URL",
+				);
+			}
+
+			if (!requestResult.data) {
+				throw new Error("Failed to get upload URL");
+			}
+
+			const { id: fileId, uploadUrl, uploadHeaders } = requestResult.data;
+
+			if (!uploadUrl) {
+				throw new Error("No upload URL returned");
+			}
+
+			const headers: Record<string, string> = {};
+			if (uploadHeaders) {
+				for (const header of uploadHeaders) {
+					headers[header.key as string] = header.value as string;
+				}
+			}
+
+			const uploadResponse = await fetch(uploadUrl, {
+				method: "PUT",
+				headers,
+				body: file,
+			});
+
+			if (!uploadResponse.ok) {
+				throw new Error(`Upload failed: ${uploadResponse.statusText}`);
+			}
+
+			const confirmResult = await confirmFileUpload({
+				identity: fileId,
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!confirmResult.success) {
+				throw new Error(
+					confirmResult.errors?.[0]?.message || "Failed to confirm upload",
+				);
+			}
+
+			const updateResult = await updateAvatar({
+				identity: props.userId,
+				input: { fileId },
+				fields: ["id", "displayAvatar"],
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!updateResult.success) {
+				throw new Error(
+					updateResult.errors[0]?.message || "Failed to update avatar",
+				);
+			}
+
+			setUploadSuccess(true);
+		} catch (error) {
+			console.error("Avatar upload error:", error);
+			setUploadError(error instanceof Error ? error.message : "Upload failed");
+		} finally {
+			setIsUploading(false);
+		}
+	};
+
+	const handleFileSelect = (e: Event) => {
+		const target = e.target as HTMLInputElement;
+		const file = target.files?.[0];
+		if (file) {
+			if (!file.type.startsWith("image/")) {
+				setUploadError("Please select an image file");
+				return;
+			}
+			if (file.size > 5 * 1024 * 1024) {
+				setUploadError("File size must be less than 5MB");
+				return;
+			}
+			handleAvatarUpload(file);
+		}
+	};
+
+	return (
+		<div>
+			<label
+				class="mb-2 block font-medium text-gray-700 text-sm"
+				for="avatar-upload">
+				{t("settings.profileAvatar")}
+			</label>
+			<div class="flex items-center space-x-4">
+				<div class="relative h-20 w-20">
+					<div class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-purple-500 to-pink-500">
+						<Show
+							fallback={
+								<span class="font-bold text-2xl text-white">
+									{props.displayName?.[0]?.toUpperCase() || "U"}
+								</span>
+							}
+							when={props.currentAvatarUrl}>
+							<img
+								alt="Avatar"
+								class="h-full w-full object-cover"
+								src={props.currentAvatarUrl ?? ""}
+							/>
+						</Show>
+					</div>
+					<Show when={isUploading()}>
+						<div class="absolute inset-0 flex items-center justify-center rounded-full bg-black/50">
+							<div class="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
+						</div>
+					</Show>
+				</div>
+				<div class="flex-1">
+					<input
+						accept="image/*"
+						class="hidden"
+						id="avatar-upload"
+						onChange={handleFileSelect}
+						ref={fileInputRef}
+						type="file"
+					/>
+					<button
+						class={`rounded-lg bg-purple-600 px-4 py-2 text-sm text-white transition-colors ${
+							isUploading()
+								? "cursor-not-allowed opacity-50"
+								: "hover:bg-purple-700"
+						}`}
+						disabled={isUploading()}
+						onClick={() => fileInputRef?.click()}
+						type="button">
+						{isUploading()
+							? t("settings.uploading")
+							: t("settings.uploadNewAvatar")}
+					</button>
+					<p class="mt-1 text-gray-500 text-xs">{t("settings.avatarHelp")}</p>
+					<Show when={uploadError()}>
+						<p class="mt-1 text-red-600 text-xs">{uploadError()}</p>
+					</Show>
+					<Show when={uploadSuccess()}>
+						<p class="mt-1 text-green-600 text-xs">
+							{t("settings.avatarUpdated")}
+						</p>
+					</Show>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/settings/DonationSettingsForm.tsx
+++ b/frontend/src/components/settings/DonationSettingsForm.tsx
@@ -1,0 +1,210 @@
+import { For, Show, createEffect, createSignal } from "solid-js";
+import { useTranslation } from "~/i18n";
+import { saveDonationSettings } from "~/sdk/ash_rpc";
+
+interface DonationSettingsFormProps {
+	userId: string;
+	initialMinAmount: number | null | undefined;
+	initialMaxAmount: number | null | undefined;
+	initialCurrency: string | null | undefined;
+	initialDefaultVoice: string | null | undefined;
+}
+
+const CURRENCIES = ["USD", "EUR", "GBP", "CAD", "AUD"];
+
+export default function DonationSettingsForm(props: DonationSettingsFormProps) {
+	const { t } = useTranslation();
+	const [minAmount, setMinAmount] = createSignal<number | null>(null);
+	const [maxAmount, setMaxAmount] = createSignal<number | null>(null);
+	const [currency, setCurrency] = createSignal("USD");
+	const [defaultVoice, setDefaultVoice] = createSignal("random");
+	const [isSavingSettings, setIsSavingSettings] = createSignal(false);
+	const [saveError, setSaveError] = createSignal<string | null>(null);
+	const [saveSuccess, setSaveSuccess] = createSignal(false);
+	const [formInitialized, setFormInitialized] = createSignal(false);
+
+	createEffect(() => {
+		if (!formInitialized()) {
+			setMinAmount(props.initialMinAmount ?? null);
+			setMaxAmount(props.initialMaxAmount ?? null);
+			setCurrency(props.initialCurrency || "USD");
+			setDefaultVoice(props.initialDefaultVoice || "random");
+			setFormInitialized(true);
+		}
+	});
+
+	const handleSaveDonationSettings = async (e: Event) => {
+		e.preventDefault();
+
+		setIsSavingSettings(true);
+		setSaveError(null);
+		setSaveSuccess(false);
+
+		try {
+			const result = await saveDonationSettings({
+				identity: props.userId,
+				input: {
+					minAmount: minAmount() ?? undefined,
+					maxAmount: maxAmount() ?? undefined,
+					currency: currency(),
+					defaultVoice: defaultVoice(),
+				},
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!result.success) {
+				throw new Error(result.errors[0]?.message || "Failed to save settings");
+			}
+
+			setSaveSuccess(true);
+			setTimeout(() => setSaveSuccess(false), 3000);
+		} catch (error) {
+			console.error("Save donation settings error:", error);
+			setSaveError(
+				error instanceof Error ? error.message : "Failed to save settings",
+			);
+		} finally {
+			setIsSavingSettings(false);
+		}
+	};
+
+	return (
+		<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+			<h3 class="mb-6 font-medium text-gray-900 text-lg">
+				{t("settings.donationSettings")}
+			</h3>
+			<form class="space-y-4" onSubmit={handleSaveDonationSettings}>
+				<div class="grid gap-4 md:grid-cols-3">
+					<div>
+						<label class="block font-medium text-gray-700 text-sm">
+							{t("settings.minimumAmount")}
+							<div class="relative mt-2">
+								<div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+									<span class="text-gray-500 text-sm">{currency()}</span>
+								</div>
+								<input
+									class="w-full rounded-lg border border-gray-300 py-2 pr-3 pl-12 text-sm focus:border-transparent focus:ring-2 focus:ring-purple-500"
+									onInput={(e) => {
+										const val = e.currentTarget.value;
+										setMinAmount(val ? Number.parseInt(val, 10) : null);
+									}}
+									placeholder={t("settings.noMinimum")}
+									type="number"
+									value={minAmount() ?? ""}
+								/>
+							</div>
+						</label>
+						<p class="mt-1 text-gray-500 text-xs">
+							{t("settings.leaveEmptyNoMin")}
+						</p>
+					</div>
+
+					<div>
+						<label class="block font-medium text-gray-700 text-sm">
+							{t("settings.maximumAmount")}
+							<div class="relative mt-2">
+								<div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+									<span class="text-gray-500 text-sm">{currency()}</span>
+								</div>
+								<input
+									class="w-full rounded-lg border border-gray-300 py-2 pr-3 pl-12 text-sm focus:border-transparent focus:ring-2 focus:ring-purple-500"
+									onInput={(e) => {
+										const val = e.currentTarget.value;
+										setMaxAmount(val ? Number.parseInt(val, 10) : null);
+									}}
+									placeholder={t("settings.noMaximum")}
+									type="number"
+									value={maxAmount() ?? ""}
+								/>
+							</div>
+						</label>
+						<p class="mt-1 text-gray-500 text-xs">
+							{t("settings.leaveEmptyNoMax")}
+						</p>
+					</div>
+
+					<div>
+						<label class="block font-medium text-gray-700 text-sm">
+							{t("settings.currency")}
+							<select
+								class="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-purple-500"
+								onChange={(e) => setCurrency(e.currentTarget.value)}
+								value={currency()}>
+								<For each={CURRENCIES}>
+									{(curr) => <option value={curr}>{curr}</option>}
+								</For>
+							</select>
+						</label>
+					</div>
+				</div>
+
+				<div>
+					<label class="block font-medium text-gray-700 text-sm">
+						{t("settings.defaultTtsVoice")}
+						<select
+							class="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-purple-500"
+							onChange={(e) => setDefaultVoice(e.currentTarget.value)}
+							value={defaultVoice()}>
+							<option value="random">{t("settings.randomVoice")}</option>
+							<option value="google_en_us_male">
+								Google TTS - English (US) Male
+							</option>
+							<option value="google_en_us_female">
+								Google TTS - English (US) Female
+							</option>
+						</select>
+					</label>
+					<p class="mt-1 text-gray-500 text-xs">{t("settings.voiceHelp")}</p>
+				</div>
+
+				<div class="flex items-start space-x-3 rounded-lg bg-blue-50 p-3">
+					<svg
+						aria-hidden="true"
+						class="mt-0.5 h-5 w-5 shrink-0 text-blue-500"
+						fill="none"
+						stroke="currentColor"
+						viewBox="0 0 24 24">
+						<path
+							d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+						/>
+					</svg>
+					<div class="text-blue-800 text-sm">
+						<p class="mb-1 font-medium">{t("settings.donationLimitsInfo")}</p>
+						<ul class="space-y-1 text-blue-700">
+							<li>• {t("settings.donationLimitsItem1")}</li>
+							<li>• {t("settings.donationLimitsItem2")}</li>
+							<li>• {t("settings.donationLimitsItem3")}</li>
+							<li>• {t("settings.donationLimitsItem4")}</li>
+						</ul>
+					</div>
+				</div>
+
+				<div class="flex items-center gap-4 pt-4">
+					<button
+						class={`rounded-lg bg-purple-600 px-4 py-2 font-medium text-sm text-white transition-colors ${
+							isSavingSettings()
+								? "cursor-not-allowed opacity-50"
+								: "hover:bg-purple-700"
+						}`}
+						disabled={isSavingSettings()}
+						type="submit">
+						{isSavingSettings()
+							? t("settings.saving")
+							: t("settings.saveDonationSettings")}
+					</button>
+					<Show when={saveSuccess()}>
+						<span class="text-green-600 text-sm">
+							{t("settings.settingsSaved")}
+						</span>
+					</Show>
+					<Show when={saveError()}>
+						<span class="text-red-600 text-sm">{saveError()}</span>
+					</Show>
+				</div>
+			</form>
+		</div>
+	);
+}

--- a/frontend/src/components/settings/PlatformConnectionsPanel.tsx
+++ b/frontend/src/components/settings/PlatformConnectionsPanel.tsx
@@ -1,0 +1,184 @@
+import { For, Show, createMemo } from "solid-js";
+import StreamingAccountStats from "~/components/StreamingAccountStats";
+import { Skeleton } from "~/components/ui";
+import Button from "~/components/ui/Button";
+import { useTranslation } from "~/i18n";
+import { apiRoutes } from "~/lib/constants";
+import {
+	disconnectStreamingAccount,
+	refreshStreamingAccountStats,
+} from "~/sdk/ash_rpc";
+
+type Platform =
+	| "youtube"
+	| "twitch"
+	| "facebook"
+	| "kick"
+	| "tiktok"
+	| "trovo"
+	| "instagram"
+	| "rumble";
+
+interface StreamingAccount {
+	platform: Platform;
+	extra_data?: {
+		name?: string;
+		nickname?: string;
+		image?: string;
+	} | null;
+	sponsor_count: number | null;
+	views_last_30d: number | null;
+	follower_count: number | null;
+	unique_viewers_last_30d: number | null;
+	stats_last_refreshed_at: string | null;
+}
+
+interface PlatformConnectionsPanelProps {
+	userId: string;
+	accounts: StreamingAccount[];
+	isLoading: boolean;
+}
+
+const AVAILABLE_PLATFORMS = [
+	{
+		name: "YouTube",
+		platform: "google" as const,
+		targetPlatform: "youtube" as const,
+		color: "from-red-600 to-red-700",
+	},
+	{
+		name: "Twitch",
+		platform: "twitch" as const,
+		targetPlatform: "twitch" as const,
+		color: "from-purple-600 to-purple-700",
+	},
+];
+
+export default function PlatformConnectionsPanel(
+	props: PlatformConnectionsPanelProps,
+) {
+	const { t } = useTranslation();
+
+	const connectedPlatforms = createMemo(() => {
+		return new Set(props.accounts.map((a) => a.platform));
+	});
+
+	const handleRefreshStats = async (platform: Platform) => {
+		// Work around type inference issue in generated SDK - fields parameter is inferred as never[]
+		const fields: string[] = [
+			"platform",
+			"sponsorCount",
+			"viewsLast30d",
+			"followerCount",
+			"uniqueViewersLast30d",
+			"statsLastRefreshedAt",
+		];
+		const result = await refreshStreamingAccountStats({
+			identity: { userId: props.userId, platform },
+			// biome-ignore lint/suspicious/noExplicitAny: Type coercion for RPC fields array
+			fields: fields as any,
+			fetchOptions: { credentials: "include" },
+		});
+
+		if (!result.success) {
+			console.error("Failed to refresh stats:", result.errors);
+		}
+	};
+
+	const handleDisconnectAccount = async (platform: Platform) => {
+		const result = await disconnectStreamingAccount({
+			identity: { userId: props.userId, platform },
+			fetchOptions: { credentials: "include" },
+		});
+
+		if (!result.success) {
+			console.error("Failed to disconnect account:", result.errors);
+		}
+	};
+
+	return (
+		<div>
+			<p class="mb-2 block font-medium text-gray-700 text-sm">
+				{t("settings.streamingPlatforms")}
+			</p>
+
+			<Show
+				fallback={
+					<div class="space-y-2">
+						<For each={[1, 2]}>
+							{() => (
+								<div class="flex items-center justify-between rounded-lg border border-gray-200 p-3">
+									<div class="flex items-center space-x-3">
+										<Skeleton class="h-10 w-10 rounded-lg" />
+										<div class="space-y-1">
+											<Skeleton class="h-4 w-20" />
+											<Skeleton class="h-3 w-16" />
+										</div>
+									</div>
+									<Skeleton class="h-8 w-20 rounded-lg" />
+								</div>
+							)}
+						</For>
+					</div>
+				}
+				when={!props.isLoading}>
+				<Show when={props.accounts.length > 0}>
+					<div class="mb-4 space-y-3">
+						<For each={props.accounts}>
+							{(account) => (
+								<StreamingAccountStats
+									data={{
+										platform: account.platform,
+										accountName:
+											account.extra_data?.name ||
+											account.extra_data?.nickname ||
+											account.platform,
+										accountImage: account.extra_data?.image || null,
+										sponsorCount: account.sponsor_count,
+										viewsLast30d: account.views_last_30d,
+										followerCount: account.follower_count,
+										uniqueViewersLast30d: account.unique_viewers_last_30d,
+										statsLastRefreshedAt: account.stats_last_refreshed_at,
+									}}
+									onDisconnect={() => handleDisconnectAccount(account.platform)}
+									onRefresh={() => handleRefreshStats(account.platform)}
+								/>
+							)}
+						</For>
+					</div>
+				</Show>
+
+				<div class="space-y-2">
+					<For each={AVAILABLE_PLATFORMS}>
+						{(platform) => (
+							<Show when={!connectedPlatforms().has(platform.targetPlatform)}>
+								<div class="flex items-center justify-between rounded-lg border border-gray-200 p-3">
+									<div class="flex items-center space-x-3">
+										<div
+											class={`h-10 w-10 bg-linear-to-r ${platform.color} flex items-center justify-center rounded-lg`}>
+											<span class="font-bold text-sm text-white">
+												{platform.name[0]}
+											</span>
+										</div>
+										<div>
+											<p class="font-medium text-gray-900">{platform.name}</p>
+											<p class="text-gray-500 text-sm">
+												{t("settings.notConnected")}
+											</p>
+										</div>
+									</div>
+									<Button
+										as="a"
+										href={apiRoutes.streaming.connect(platform.platform)}
+										size="sm">
+										{t("settings.connect")}
+									</Button>
+								</div>
+							</Show>
+						)}
+					</For>
+				</div>
+			</Show>
+		</div>
+	);
+}

--- a/frontend/src/components/settings/UserRolesManagement.tsx
+++ b/frontend/src/components/settings/UserRolesManagement.tsx
@@ -1,0 +1,644 @@
+import { For, Show, createEffect, createSignal } from "solid-js";
+import { useTranslation } from "~/i18n";
+import {
+	acceptRoleInvitation,
+	declineRoleInvitation,
+	getUserByName,
+	getUserInfo,
+	inviteUserRole,
+	revokeUserRole,
+} from "~/sdk/ash_rpc";
+
+type UserInfo = { id: string; name: string; displayAvatar: string | null };
+
+interface UserRole {
+	id: string;
+	user_id: string;
+	granter_id: string;
+	role_type: string;
+	role_status: string;
+	granted_at: string;
+	accepted_at: string | null;
+}
+
+interface UserRolesManagementProps {
+	userId: string;
+	pendingInvitations: UserRole[];
+	myRoles: UserRole[];
+	rolesIGranted: UserRole[];
+	pendingInvitationsSent: UserRole[];
+	isLoading: boolean;
+}
+
+const formatRoleType = (roleType: string) => {
+	return roleType.charAt(0).toUpperCase() + roleType.slice(1);
+};
+
+const formatDate = (dateString: string) => {
+	return new Date(dateString).toLocaleDateString();
+};
+
+export default function UserRolesManagement(props: UserRolesManagementProps) {
+	const { t } = useTranslation();
+	const [inviteUsername, setInviteUsername] = createSignal("");
+	const [inviteRoleType, setInviteRoleType] = createSignal<
+		"moderator" | "manager"
+	>("moderator");
+	const [isInviting, setIsInviting] = createSignal(false);
+	const [inviteError, setInviteError] = createSignal<string | null>(null);
+	const [inviteSuccess, setInviteSuccess] = createSignal(false);
+	const [processingRoleId, setProcessingRoleId] = createSignal<string | null>(
+		null,
+	);
+	const [userInfoCache, setUserInfoCache] = createSignal<Map<string, UserInfo>>(
+		new Map(),
+	);
+
+	const fetchUserInfo = async (userId: string): Promise<UserInfo | null> => {
+		const cached = userInfoCache().get(userId);
+		if (cached) return cached;
+
+		try {
+			const result = await getUserInfo({
+				input: { id: userId },
+				fields: ["id", "name", "displayAvatar"],
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (result.success && result.data) {
+				const info: UserInfo = {
+					id: result.data.id,
+					name: result.data.name,
+					displayAvatar: result.data.displayAvatar,
+				};
+				setUserInfoCache((prev) => new Map(prev).set(userId, info));
+				return info;
+			}
+		} catch (e) {
+			console.error("Failed to fetch user info:", e);
+		}
+		return null;
+	};
+
+	createEffect(() => {
+		const allRoles = [
+			...props.pendingInvitations,
+			...props.myRoles,
+			...props.rolesIGranted,
+			...props.pendingInvitationsSent,
+		];
+		const userIds = new Set<string>();
+
+		for (const role of allRoles) {
+			userIds.add(role.user_id);
+			userIds.add(role.granter_id);
+		}
+
+		for (const userId of userIds) {
+			if (!userInfoCache().has(userId)) {
+				fetchUserInfo(userId);
+			}
+		}
+	});
+
+	const getUserInfoCached = (userId: string): UserInfo | null => {
+		return userInfoCache().get(userId) || null;
+	};
+
+	const handleInviteUser = async (e: Event) => {
+		e.preventDefault();
+
+		const username = inviteUsername().trim();
+		if (!username) {
+			setInviteError("Please enter a username");
+			return;
+		}
+
+		setIsInviting(true);
+		setInviteError(null);
+		setInviteSuccess(false);
+
+		try {
+			const lookupResult = await getUserByName({
+				input: { name: username },
+				fields: ["id", "name", "displayAvatar"],
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!lookupResult.success || !lookupResult.data) {
+				throw new Error(`User "${username}" not found`);
+			}
+
+			const targetUser = lookupResult.data;
+
+			if (targetUser.id === props.userId) {
+				throw new Error("You cannot invite yourself");
+			}
+
+			const result = await inviteUserRole({
+				input: {
+					userId: targetUser.id,
+					granterId: props.userId,
+					roleType: inviteRoleType(),
+				},
+				fields: ["id", "roleType", "roleStatus"],
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!result.success) {
+				throw new Error(
+					result.errors[0]?.message || "Failed to send invitation",
+				);
+			}
+
+			setInviteSuccess(true);
+			setInviteUsername("");
+			setTimeout(() => setInviteSuccess(false), 3000);
+		} catch (error) {
+			console.error("Invite error:", error);
+			setInviteError(
+				error instanceof Error ? error.message : "Failed to send invitation",
+			);
+		} finally {
+			setIsInviting(false);
+		}
+	};
+
+	const handleAcceptInvitation = async (roleId: string) => {
+		setProcessingRoleId(roleId);
+		try {
+			const result = await acceptRoleInvitation({
+				identity: roleId,
+				fields: ["id", "roleStatus"],
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!result.success) {
+				throw new Error(
+					result.errors[0]?.message || "Failed to accept invitation",
+				);
+			}
+		} catch (error) {
+			console.error("Accept invitation error:", error);
+		} finally {
+			setProcessingRoleId(null);
+		}
+	};
+
+	const handleDeclineInvitation = async (roleId: string) => {
+		setProcessingRoleId(roleId);
+		try {
+			const result = await declineRoleInvitation({
+				identity: roleId,
+				fields: ["id", "roleStatus"],
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!result.success) {
+				throw new Error(
+					result.errors[0]?.message || "Failed to decline invitation",
+				);
+			}
+		} catch (error) {
+			console.error("Decline invitation error:", error);
+		} finally {
+			setProcessingRoleId(null);
+		}
+	};
+
+	const handleRevokeRole = async (roleId: string) => {
+		if (!confirm("Are you sure you want to revoke this role?")) return;
+
+		setProcessingRoleId(roleId);
+		try {
+			const result = await revokeUserRole({
+				identity: roleId,
+				fields: ["id", "revokedAt"],
+				fetchOptions: { credentials: "include" },
+			});
+
+			if (!result.success) {
+				throw new Error(result.errors[0]?.message || "Failed to revoke role");
+			}
+		} catch (error) {
+			console.error("Revoke role error:", error);
+		} finally {
+			setProcessingRoleId(null);
+		}
+	};
+
+	return (
+		<>
+			{/* Pending Invitations Section */}
+			<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+				<h3 class="mb-6 font-medium text-gray-900 text-lg">
+					{t("settings.roleInvitations")}
+				</h3>
+				<Show
+					fallback={
+						<div class="py-8 text-center text-gray-500">
+							<svg
+								aria-hidden="true"
+								class="mx-auto mb-3 h-12 w-12 text-gray-400"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24">
+								<path
+									d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+								/>
+							</svg>
+							<p class="text-sm">{t("settings.noPendingInvitations")}</p>
+							<p class="mt-1 text-gray-400 text-xs">
+								{t("settings.invitationsHelp")}
+							</p>
+						</div>
+					}
+					when={!props.isLoading && props.pendingInvitations.length > 0}>
+					<div class="space-y-3">
+						<For each={props.pendingInvitations}>
+							{(invitation) => {
+								const granterInfo = () =>
+									getUserInfoCached(invitation.granter_id);
+								return (
+									<div class="flex items-center justify-between rounded-lg border border-gray-200 p-4">
+										<div class="flex items-center gap-3">
+											<div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-purple-500 to-pink-500">
+												<Show
+													fallback={
+														<span class="font-bold text-white">
+															{granterInfo()?.name?.[0]?.toUpperCase() || "?"}
+														</span>
+													}
+													when={granterInfo()?.displayAvatar}>
+													<img
+														alt={granterInfo()?.name || "User"}
+														class="h-full w-full object-cover"
+														src={granterInfo()?.displayAvatar ?? ""}
+													/>
+												</Show>
+											</div>
+											<div>
+												<p class="font-medium text-gray-900">
+													{granterInfo()?.name || "Loading..."}
+												</p>
+												<p class="text-gray-500 text-sm">
+													{t("settings.invitedYouAs")}{" "}
+													<span class="font-medium text-purple-600">
+														{formatRoleType(invitation.role_type)}
+													</span>
+												</p>
+												<p class="text-gray-400 text-xs">
+													{formatDate(invitation.granted_at)}
+												</p>
+											</div>
+										</div>
+										<div class="flex gap-2">
+											<button
+												class="rounded-lg bg-green-600 px-3 py-1.5 font-medium text-sm text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+												disabled={processingRoleId() === invitation.id}
+												onClick={() => handleAcceptInvitation(invitation.id)}
+												type="button">
+												{processingRoleId() === invitation.id
+													? "..."
+													: t("settings.accept")}
+											</button>
+											<button
+												class="rounded-lg bg-gray-200 px-3 py-1.5 font-medium text-gray-700 text-sm transition-colors hover:bg-gray-300 disabled:opacity-50"
+												disabled={processingRoleId() === invitation.id}
+												onClick={() => handleDeclineInvitation(invitation.id)}
+												type="button">
+												{t("settings.decline")}
+											</button>
+										</div>
+									</div>
+								);
+							}}
+						</For>
+					</div>
+				</Show>
+			</div>
+
+			{/* My Roles in Other Channels */}
+			<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+				<h3 class="mb-6 font-medium text-gray-900 text-lg">
+					{t("settings.myRolesInChannels")}
+				</h3>
+				<Show
+					fallback={
+						<div class="py-8 text-center text-gray-500">
+							<svg
+								aria-hidden="true"
+								class="mx-auto mb-3 h-12 w-12 text-gray-400"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24">
+								<path
+									d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+								/>
+							</svg>
+							<p class="text-sm">{t("settings.noRolesInChannels")}</p>
+							<p class="mt-1 text-gray-400 text-xs">
+								{t("settings.rolesGrantedHelp")}
+							</p>
+						</div>
+					}
+					when={!props.isLoading && props.myRoles.length > 0}>
+					<div class="space-y-3">
+						<For each={props.myRoles}>
+							{(role) => {
+								const granterInfo = () => getUserInfoCached(role.granter_id);
+								return (
+									<div class="flex items-center justify-between rounded-lg border border-gray-200 p-4">
+										<div class="flex items-center gap-3">
+											<div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-purple-500 to-pink-500">
+												<Show
+													fallback={
+														<span class="font-bold text-white">
+															{granterInfo()?.name?.[0]?.toUpperCase() || "?"}
+														</span>
+													}
+													when={granterInfo()?.displayAvatar}>
+													<img
+														alt={granterInfo()?.name || "User"}
+														class="h-full w-full object-cover"
+														src={granterInfo()?.displayAvatar ?? ""}
+													/>
+												</Show>
+											</div>
+											<div>
+												<p class="font-medium text-gray-900">
+													{granterInfo()?.name || "Loading..."}
+													{t("settings.channel")}
+												</p>
+												<p class="text-gray-500 text-sm">
+													<span class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 font-medium text-purple-800 text-xs">
+														{formatRoleType(role.role_type)}
+													</span>
+												</p>
+												<p class="mt-1 text-gray-400 text-xs">
+													{t("settings.since")}{" "}
+													{formatDate(role.accepted_at || role.granted_at)}
+												</p>
+											</div>
+										</div>
+									</div>
+								);
+							}}
+						</For>
+					</div>
+				</Show>
+			</div>
+
+			{/* Divider */}
+			<div class="relative">
+				<div class="absolute inset-0 flex items-center">
+					<div class="w-full border-gray-300 border-t" />
+				</div>
+				<div class="relative flex justify-center text-sm">
+					<span class="bg-gray-50 px-2 text-gray-500">
+						{t("settings.channelManagement")}
+					</span>
+				</div>
+			</div>
+
+			{/* Role Management Section */}
+			<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+				<h3 class="mb-6 font-medium text-gray-900 text-lg">
+					{t("settings.roleManagement")}
+				</h3>
+
+				{/* Invite User Form */}
+				<div class="mb-6 rounded-lg bg-gray-50 p-4">
+					<h4 class="mb-3 font-medium text-gray-900">
+						{t("settings.inviteUser")}
+					</h4>
+					<form class="space-y-3" onSubmit={handleInviteUser}>
+						<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+							<div>
+								<input
+									class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+									onInput={(e) => setInviteUsername(e.currentTarget.value)}
+									placeholder={t("settings.enterUsername")}
+									type="text"
+									value={inviteUsername()}
+								/>
+							</div>
+							<div>
+								<select
+									class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+									onChange={(e) =>
+										setInviteRoleType(
+											e.currentTarget.value as "moderator" | "manager",
+										)
+									}
+									value={inviteRoleType()}>
+									<option value="moderator">{t("settings.moderator")}</option>
+									<option value="manager">{t("settings.manager")}</option>
+								</select>
+							</div>
+							<div>
+								<button
+									class={`w-full rounded-lg bg-purple-600 px-4 py-2 font-medium text-sm text-white transition-colors ${
+										isInviting()
+											? "cursor-not-allowed opacity-50"
+											: "hover:bg-purple-700"
+									}`}
+									disabled={isInviting()}
+									type="submit">
+									{isInviting()
+										? t("settings.sending")
+										: t("settings.sendInvitation")}
+								</button>
+							</div>
+						</div>
+						<Show when={inviteError()}>
+							<p class="text-red-600 text-sm">{inviteError()}</p>
+						</Show>
+						<Show when={inviteSuccess()}>
+							<p class="text-green-600 text-sm">
+								{t("settings.invitationSent")}
+							</p>
+						</Show>
+					</form>
+					<div class="mt-3 rounded-lg bg-blue-50 p-3">
+						<div class="flex">
+							<svg
+								aria-hidden="true"
+								class="mr-2 h-5 w-5 shrink-0 text-blue-500"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24">
+								<path
+									d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+								/>
+							</svg>
+							<div class="text-blue-800 text-sm">
+								<p class="font-medium">{t("settings.rolePermissions")}</p>
+								<ul class="mt-1 space-y-1 text-blue-700 text-xs">
+									<li>
+										• <strong>{t("settings.moderator")}:</strong>{" "}
+										{t("settings.moderatorDesc")}
+									</li>
+									<li>
+										• <strong>{t("settings.manager")}:</strong>{" "}
+										{t("settings.managerDesc")}
+									</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				{/* Pending Invitations Sent */}
+				<Show
+					when={!props.isLoading && props.pendingInvitationsSent.length > 0}>
+					<div class="mb-6 space-y-3">
+						<h4 class="font-medium text-gray-700 text-sm">
+							{t("settings.pendingInvitations")}
+						</h4>
+						<For each={props.pendingInvitationsSent}>
+							{(role) => {
+								const userInfo = () => getUserInfoCached(role.user_id);
+								return (
+									<div class="flex items-center justify-between rounded-lg border border-yellow-200 bg-yellow-50 p-4">
+										<div class="flex items-center gap-3">
+											<div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-yellow-400 to-orange-400">
+												<Show
+													fallback={
+														<span class="font-bold text-white">
+															{userInfo()?.name?.[0]?.toUpperCase() || "?"}
+														</span>
+													}
+													when={userInfo()?.displayAvatar}>
+													<img
+														alt={userInfo()?.name || "User"}
+														class="h-full w-full object-cover"
+														src={userInfo()?.displayAvatar ?? ""}
+													/>
+												</Show>
+											</div>
+											<div>
+												<p class="font-medium text-gray-900">
+													{userInfo()?.name || "Loading..."}
+												</p>
+												<p class="text-gray-500 text-sm">
+													<span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 font-medium text-xs text-yellow-800">
+														{formatRoleType(role.role_type)} (
+														{t("settings.pending")})
+													</span>
+												</p>
+												<p class="mt-1 text-gray-400 text-xs">
+													Invited {formatDate(role.granted_at)}
+												</p>
+											</div>
+										</div>
+										<button
+											class="rounded-lg px-3 py-1.5 font-medium text-red-600 text-sm transition-colors hover:bg-red-50 disabled:opacity-50"
+											disabled={processingRoleId() === role.id}
+											onClick={() => handleRevokeRole(role.id)}
+											type="button">
+											{processingRoleId() === role.id
+												? "..."
+												: t("settings.cancel")}
+										</button>
+									</div>
+								);
+							}}
+						</For>
+					</div>
+				</Show>
+
+				{/* Team Members (Roles I Granted) */}
+				<Show
+					fallback={
+						<Show when={props.pendingInvitationsSent.length === 0}>
+							<div class="py-8 text-center text-gray-500">
+								<svg
+									aria-hidden="true"
+									class="mx-auto mb-3 h-12 w-12 text-gray-400"
+									fill="none"
+									stroke="currentColor"
+									viewBox="0 0 24 24">
+									<path
+										d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+									/>
+								</svg>
+								<p class="text-sm">{t("settings.noRolesGranted")}</p>
+								<p class="mt-1 text-gray-400 text-xs">
+									{t("settings.rolesGrantedToHelp")}
+								</p>
+							</div>
+						</Show>
+					}
+					when={!props.isLoading && props.rolesIGranted.length > 0}>
+					<div class="space-y-3">
+						<h4 class="font-medium text-gray-700 text-sm">
+							{t("settings.yourTeam")}
+						</h4>
+						<For each={props.rolesIGranted}>
+							{(role) => {
+								const userInfo = () => getUserInfoCached(role.user_id);
+								return (
+									<div class="flex items-center justify-between rounded-lg border border-gray-200 p-4">
+										<div class="flex items-center gap-3">
+											<div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-purple-500 to-pink-500">
+												<Show
+													fallback={
+														<span class="font-bold text-white">
+															{userInfo()?.name?.[0]?.toUpperCase() || "?"}
+														</span>
+													}
+													when={userInfo()?.displayAvatar}>
+													<img
+														alt={userInfo()?.name || "User"}
+														class="h-full w-full object-cover"
+														src={userInfo()?.displayAvatar ?? ""}
+													/>
+												</Show>
+											</div>
+											<div>
+												<p class="font-medium text-gray-900">
+													{userInfo()?.name || "Loading..."}
+												</p>
+												<p class="text-gray-500 text-sm">
+													<span class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 font-medium text-purple-800 text-xs">
+														{formatRoleType(role.role_type)}
+													</span>
+												</p>
+												<p class="mt-1 text-gray-400 text-xs">
+													{t("settings.since")}{" "}
+													{formatDate(role.accepted_at || role.granted_at)}
+												</p>
+											</div>
+										</div>
+										<button
+											class="rounded-lg px-3 py-1.5 font-medium text-red-600 text-sm transition-colors hover:bg-red-50 disabled:opacity-50"
+											disabled={processingRoleId() === role.id}
+											onClick={() => handleRevokeRole(role.id)}
+											type="button">
+											{processingRoleId() === role.id
+												? "..."
+												: t("settings.revoke")}
+										</button>
+									</div>
+								);
+							}}
+						</For>
+					</div>
+				</Show>
+			</div>
+		</>
+	);
+}

--- a/frontend/src/components/settings/index.ts
+++ b/frontend/src/components/settings/index.ts
@@ -1,0 +1,4 @@
+export { default as AvatarUploadSection } from "./AvatarUploadSection";
+export { default as DonationSettingsForm } from "./DonationSettingsForm";
+export { default as PlatformConnectionsPanel } from "./PlatformConnectionsPanel";
+export { default as UserRolesManagement } from "./UserRolesManagement";

--- a/frontend/src/routes/dashboard/settings.tsx
+++ b/frontend/src/routes/dashboard/settings.tsx
@@ -1,35 +1,21 @@
 import { Title } from "@solidjs/meta";
 import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 import LanguageSwitcher from "~/components/LanguageSwitcher";
-import StreamingAccountStats from "~/components/StreamingAccountStats";
+import {
+	AvatarUploadSection,
+	DonationSettingsForm,
+	PlatformConnectionsPanel,
+	UserRolesManagement,
+} from "~/components/settings";
 import { Skeleton } from "~/components/ui";
-import Button from "~/components/ui/Button";
 import { useTranslation } from "~/i18n";
 import { getLoginUrl, useCurrentUser } from "~/lib/auth";
-import { apiRoutes } from "~/lib/constants";
 import {
 	useStreamingAccounts,
 	useUserPreferencesForUser,
 	useUserRolesData,
 } from "~/lib/useElectric";
-import {
-	acceptRoleInvitation,
-	confirmFileUpload,
-	declineRoleInvitation,
-	disconnectStreamingAccount,
-	getUserByName,
-	getUserInfo,
-	inviteUserRole,
-	refreshStreamingAccountStats,
-	requestFileUpload,
-	revokeUserRole,
-	saveDonationSettings,
-	toggleEmailNotifications,
-	updateAvatar,
-	updateName,
-} from "~/sdk/ash_rpc";
-
-type UserInfo = { id: string; name: string; displayAvatar: string | null };
+import { toggleEmailNotifications, updateName } from "~/sdk/ash_rpc";
 
 // Skeleton for settings page
 function SettingsPageSkeleton() {
@@ -112,67 +98,15 @@ export default function Settings() {
 	const prefs = useUserPreferencesForUser(() => user()?.id);
 	const rolesData = useUserRolesData(() => user()?.id);
 	const streamingAccounts = useStreamingAccounts(() => user()?.id);
-	const [isUploading, setIsUploading] = createSignal(false);
-	const [uploadError, setUploadError] = createSignal<string | null>(null);
-	const [uploadSuccess, setUploadSuccess] = createSignal(false);
-	let fileInputRef: HTMLInputElement | undefined;
-
-	const [minAmount, setMinAmount] = createSignal<number | null>(null);
-	const [maxAmount, setMaxAmount] = createSignal<number | null>(null);
-	const [currency, setCurrency] = createSignal("USD");
-	const [defaultVoice, setDefaultVoice] = createSignal("random");
-	const [isSavingSettings, setIsSavingSettings] = createSignal(false);
-	const [saveError, setSaveError] = createSignal<string | null>(null);
-	const [saveSuccess, setSaveSuccess] = createSignal(false);
 
 	const [displayName, setDisplayName] = createSignal("");
 	const [isUpdatingName, setIsUpdatingName] = createSignal(false);
 	const [nameError, setNameError] = createSignal<string | null>(null);
 	const [nameSuccess, setNameSuccess] = createSignal(false);
-
 	const [isTogglingNotifications, setIsTogglingNotifications] =
 		createSignal(false);
 
-	const [inviteUsername, setInviteUsername] = createSignal("");
-	const [inviteRoleType, setInviteRoleType] = createSignal<
-		"moderator" | "manager"
-	>("moderator");
-	const [isInviting, setIsInviting] = createSignal(false);
-	const [inviteError, setInviteError] = createSignal<string | null>(null);
-	const [inviteSuccess, setInviteSuccess] = createSignal(false);
-	const [processingRoleId, setProcessingRoleId] = createSignal<string | null>(
-		null,
-	);
-
-	const [userInfoCache, setUserInfoCache] = createSignal<Map<string, UserInfo>>(
-		new Map(),
-	);
-
-	const fetchUserInfo = async (userId: string): Promise<UserInfo | null> => {
-		const cached = userInfoCache().get(userId);
-		if (cached) return cached;
-
-		try {
-			const result = await getUserInfo({
-				input: { id: userId },
-				fields: ["id", "name", "displayAvatar"],
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (result.success && result.data) {
-				const info: UserInfo = {
-					id: result.data.id,
-					name: result.data.name,
-					displayAvatar: result.data.displayAvatar,
-				};
-				setUserInfoCache((prev) => new Map(prev).set(userId, info));
-				return info;
-			}
-		} catch (e) {
-			console.error("Failed to fetch user info:", e);
-		}
-		return null;
-	};
+	const [formInitialized, setFormInitialized] = createSignal(false);
 
 	const pendingInvitations = createMemo(
 		() => rolesData.data().pendingInvitations,
@@ -185,80 +119,12 @@ export default function Settings() {
 	const loadingRoles = createMemo(() => rolesData.isLoading());
 
 	createEffect(() => {
-		const allRoles = [
-			...pendingInvitations(),
-			...myRoles(),
-			...rolesIGranted(),
-			...pendingInvitationsSent(),
-		];
-		const userIds = new Set<string>();
-
-		for (const role of allRoles) {
-			userIds.add(role.user_id);
-			userIds.add(role.granter_id);
-		}
-
-		for (const userId of userIds) {
-			if (!userInfoCache().has(userId)) {
-				fetchUserInfo(userId);
-			}
-		}
-	});
-
-	const getUserInfo_cached = (userId: string): UserInfo | null => {
-		return userInfoCache().get(userId) || null;
-	};
-
-	const [formInitialized, setFormInitialized] = createSignal(false);
-
-	createEffect(() => {
 		const data = prefs.data();
 		if (data && !formInitialized()) {
-			setMinAmount(data.min_donation_amount);
-			setMaxAmount(data.max_donation_amount);
-			setCurrency(data.donation_currency || "USD");
-			setDefaultVoice(data.default_voice || "random");
 			setDisplayName(data.name || "");
 			setFormInitialized(true);
 		}
 	});
-
-	const handleSaveDonationSettings = async (e: Event) => {
-		e.preventDefault();
-		const currentUser = user();
-		if (!currentUser) return;
-
-		setIsSavingSettings(true);
-		setSaveError(null);
-		setSaveSuccess(false);
-
-		try {
-			const result = await saveDonationSettings({
-				identity: currentUser.id,
-				input: {
-					minAmount: minAmount() ?? undefined,
-					maxAmount: maxAmount() ?? undefined,
-					currency: currency(),
-					defaultVoice: defaultVoice(),
-				},
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!result.success) {
-				throw new Error(result.errors[0]?.message || "Failed to save settings");
-			}
-
-			setSaveSuccess(true);
-			setTimeout(() => setSaveSuccess(false), 3000);
-		} catch (error) {
-			console.error("Save donation settings error:", error);
-			setSaveError(
-				error instanceof Error ? error.message : "Failed to save settings",
-			);
-		} finally {
-			setIsSavingSettings(false);
-		}
-	};
 
 	const handleUpdateName = async () => {
 		const currentUser = user();
@@ -323,321 +189,6 @@ export default function Settings() {
 		}
 	};
 
-	const handleInviteUser = async (e: Event) => {
-		e.preventDefault();
-		const currentUser = user();
-		if (!currentUser) return;
-
-		const username = inviteUsername().trim();
-		if (!username) {
-			setInviteError("Please enter a username");
-			return;
-		}
-
-		setIsInviting(true);
-		setInviteError(null);
-		setInviteSuccess(false);
-
-		try {
-			const lookupResult = await getUserByName({
-				input: { name: username },
-				fields: ["id", "name", "displayAvatar"],
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!lookupResult.success || !lookupResult.data) {
-				throw new Error(`User "${username}" not found`);
-			}
-
-			const targetUser = lookupResult.data;
-
-			if (targetUser.id === currentUser.id) {
-				throw new Error("You cannot invite yourself");
-			}
-
-			const result = await inviteUserRole({
-				input: {
-					userId: targetUser.id,
-					granterId: currentUser.id,
-					roleType: inviteRoleType(),
-				},
-				fields: ["id", "roleType", "roleStatus"],
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!result.success) {
-				throw new Error(
-					result.errors[0]?.message || "Failed to send invitation",
-				);
-			}
-
-			setInviteSuccess(true);
-			setInviteUsername("");
-			setTimeout(() => setInviteSuccess(false), 3000);
-		} catch (error) {
-			console.error("Invite error:", error);
-			setInviteError(
-				error instanceof Error ? error.message : "Failed to send invitation",
-			);
-		} finally {
-			setIsInviting(false);
-		}
-	};
-
-	const handleAcceptInvitation = async (roleId: string) => {
-		setProcessingRoleId(roleId);
-		try {
-			const result = await acceptRoleInvitation({
-				identity: roleId,
-				fields: ["id", "roleStatus"],
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!result.success) {
-				throw new Error(
-					result.errors[0]?.message || "Failed to accept invitation",
-				);
-			}
-		} catch (error) {
-			console.error("Accept invitation error:", error);
-		} finally {
-			setProcessingRoleId(null);
-		}
-	};
-
-	const handleDeclineInvitation = async (roleId: string) => {
-		setProcessingRoleId(roleId);
-		try {
-			const result = await declineRoleInvitation({
-				identity: roleId,
-				fields: ["id", "roleStatus"],
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!result.success) {
-				throw new Error(
-					result.errors[0]?.message || "Failed to decline invitation",
-				);
-			}
-		} catch (error) {
-			console.error("Decline invitation error:", error);
-		} finally {
-			setProcessingRoleId(null);
-		}
-	};
-
-	const handleRevokeRole = async (roleId: string) => {
-		if (!confirm("Are you sure you want to revoke this role?")) return;
-
-		setProcessingRoleId(roleId);
-		try {
-			const result = await revokeUserRole({
-				identity: roleId,
-				fields: ["id", "revokedAt"],
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!result.success) {
-				throw new Error(result.errors[0]?.message || "Failed to revoke role");
-			}
-		} catch (error) {
-			console.error("Revoke role error:", error);
-		} finally {
-			setProcessingRoleId(null);
-		}
-	};
-
-	const formatRoleType = (roleType: string) => {
-		return roleType.charAt(0).toUpperCase() + roleType.slice(1);
-	};
-
-	const formatDate = (dateString: string) => {
-		return new Date(dateString).toLocaleDateString();
-	};
-
-	const handleAvatarUpload = async (file: File) => {
-		const currentUser = user();
-		if (!currentUser) return;
-
-		setIsUploading(true);
-		setUploadError(null);
-		setUploadSuccess(false);
-
-		try {
-			const requestResult = await requestFileUpload({
-				input: {
-					filename: file.name,
-					contentType: file.type,
-					fileType: "avatar",
-					estimatedSize: file.size,
-				},
-				fields: ["id", "uploadUrl", "uploadHeaders", "maxSize"],
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!requestResult.success) {
-				throw new Error(
-					requestResult.errors?.[0]?.message || "Failed to get upload URL",
-				);
-			}
-
-			if (!requestResult.data) {
-				throw new Error("Failed to get upload URL");
-			}
-
-			const { id: fileId, uploadUrl, uploadHeaders } = requestResult.data;
-
-			if (!uploadUrl) {
-				throw new Error("No upload URL returned");
-			}
-
-			const headers: Record<string, string> = {};
-			if (uploadHeaders) {
-				for (const header of uploadHeaders) {
-					headers[header.key as string] = header.value as string;
-				}
-			}
-
-			const uploadResponse = await fetch(uploadUrl, {
-				method: "PUT",
-				headers,
-				body: file,
-			});
-
-			if (!uploadResponse.ok) {
-				throw new Error(`Upload failed: ${uploadResponse.statusText}`);
-			}
-
-			const confirmResult = await confirmFileUpload({
-				identity: fileId,
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!confirmResult.success) {
-				throw new Error(
-					confirmResult.errors?.[0]?.message || "Failed to confirm upload",
-				);
-			}
-
-			const updateResult = await updateAvatar({
-				identity: currentUser.id,
-				input: { fileId },
-				fields: ["id", "displayAvatar"],
-				fetchOptions: { credentials: "include" },
-			});
-
-			if (!updateResult.success) {
-				throw new Error(
-					updateResult.errors[0]?.message || "Failed to update avatar",
-				);
-			}
-
-			setUploadSuccess(true);
-		} catch (error) {
-			console.error("Avatar upload error:", error);
-			setUploadError(error instanceof Error ? error.message : "Upload failed");
-		} finally {
-			setIsUploading(false);
-		}
-	};
-
-	const handleFileSelect = (e: Event) => {
-		const target = e.target as HTMLInputElement;
-		const file = target.files?.[0];
-		if (file) {
-			if (!file.type.startsWith("image/")) {
-				setUploadError("Please select an image file");
-				return;
-			}
-			if (file.size > 5 * 1024 * 1024) {
-				setUploadError("File size must be less than 5MB");
-				return;
-			}
-			handleAvatarUpload(file);
-		}
-	};
-
-	const availablePlatforms = [
-		{
-			name: "YouTube",
-			platform: "google" as const,
-			targetPlatform: "youtube" as const,
-			color: "from-red-600 to-red-700",
-		},
-		{
-			name: "Twitch",
-			platform: "twitch" as const,
-			targetPlatform: "twitch" as const,
-			color: "from-purple-600 to-purple-700",
-		},
-	];
-
-	const connectedPlatforms = createMemo(() => {
-		const accounts = streamingAccounts.data();
-		return new Set(accounts.map((a) => a.platform));
-	});
-
-	const handleRefreshStats = async (
-		platform:
-			| "youtube"
-			| "twitch"
-			| "facebook"
-			| "kick"
-			| "tiktok"
-			| "trovo"
-			| "instagram"
-			| "rumble",
-	) => {
-		const currentUser = user();
-		if (!currentUser) return;
-
-		// Work around type inference issue in generated SDK - fields parameter is inferred as never[]
-		const fields: string[] = [
-			"platform",
-			"sponsorCount",
-			"viewsLast30d",
-			"followerCount",
-			"uniqueViewersLast30d",
-			"statsLastRefreshedAt",
-		];
-		const result = await refreshStreamingAccountStats({
-			identity: { userId: currentUser.id, platform },
-			// biome-ignore lint/suspicious/noExplicitAny: Type coercion for RPC fields array
-			fields: fields as any,
-			fetchOptions: { credentials: "include" },
-		});
-
-		if (!result.success) {
-			console.error("Failed to refresh stats:", result.errors);
-		}
-	};
-
-	const handleDisconnectAccount = async (
-		platform:
-			| "youtube"
-			| "twitch"
-			| "facebook"
-			| "kick"
-			| "tiktok"
-			| "trovo"
-			| "instagram"
-			| "rumble",
-	) => {
-		const currentUser = user();
-		if (!currentUser) return;
-
-		const result = await disconnectStreamingAccount({
-			identity: { userId: currentUser.id, platform },
-			fetchOptions: { credentials: "include" },
-		});
-
-		if (!result.success) {
-			console.error("Failed to disconnect account:", result.errors);
-		}
-	};
-
-	const currencies = ["USD", "EUR", "GBP", "CAD", "AUD"];
-
 	return (
 		<>
 			<Title>Settings - Streampai</Title>
@@ -662,6 +213,7 @@ export default function Settings() {
 					}
 					when={user()}>
 					<div class="mx-auto max-w-6xl space-y-6">
+						{/* Plan Banner */}
 						<div class="rounded-lg bg-linear-to-r from-purple-600 to-pink-600 p-6 text-white shadow-sm">
 							<div class="flex items-center justify-between">
 								<div>
@@ -678,11 +230,13 @@ export default function Settings() {
 							</div>
 						</div>
 
+						{/* Account Settings */}
 						<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
 							<h3 class="mb-6 font-medium text-gray-900 text-lg">
 								{t("settings.accountSettings")}
 							</h3>
 							<div class="space-y-6">
+								{/* Email (read-only) */}
 								<div>
 									<label class="block font-medium text-gray-700 text-sm">
 										{t("settings.email")}
@@ -698,6 +252,7 @@ export default function Settings() {
 									</p>
 								</div>
 
+								{/* Display Name */}
 								<div>
 									<label class="block font-medium text-gray-700 text-sm">
 										{t("settings.displayName")}
@@ -739,171 +294,23 @@ export default function Settings() {
 									</div>
 								</div>
 
-								<div>
-									<label
-										class="mb-2 block font-medium text-gray-700 text-sm"
-										for="avatar-upload">
-										{t("settings.profileAvatar")}
-									</label>
-									<div class="flex items-center space-x-4">
-										<div class="relative h-20 w-20">
-											<div class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-purple-500 to-pink-500">
-												<Show
-													fallback={
-														<span class="font-bold text-2xl text-white">
-															{prefs.data()?.name?.[0]?.toUpperCase() || "U"}
-														</span>
-													}
-													when={prefs.data()?.avatar_url}>
-													<img
-														alt="Avatar"
-														class="h-full w-full object-cover"
-														src={prefs.data()?.avatar_url ?? ""}
-													/>
-												</Show>
-											</div>
-											<Show when={isUploading()}>
-												<div class="absolute inset-0 flex items-center justify-center rounded-full bg-black/50">
-													<div class="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
-												</div>
-											</Show>
-										</div>
-										<div class="flex-1">
-											<input
-												accept="image/*"
-												class="hidden"
-												id="avatar-upload"
-												onChange={handleFileSelect}
-												ref={fileInputRef}
-												type="file"
-											/>
-											<button
-												class={`rounded-lg bg-purple-600 px-4 py-2 text-sm text-white transition-colors ${
-													isUploading()
-														? "cursor-not-allowed opacity-50"
-														: "hover:bg-purple-700"
-												}`}
-												disabled={isUploading()}
-												onClick={() => fileInputRef?.click()}
-												type="button">
-												{isUploading()
-													? t("settings.uploading")
-													: t("settings.uploadNewAvatar")}
-											</button>
-											<p class="mt-1 text-gray-500 text-xs">
-												{t("settings.avatarHelp")}
-											</p>
-											<Show when={uploadError()}>
-												<p class="mt-1 text-red-600 text-xs">{uploadError()}</p>
-											</Show>
-											<Show when={uploadSuccess()}>
-												<p class="mt-1 text-green-600 text-xs">
-													{t("settings.avatarUpdated")}
-												</p>
-											</Show>
-										</div>
-									</div>
-								</div>
+								{/* Avatar Upload */}
+								<AvatarUploadSection
+									currentAvatarUrl={prefs.data()?.avatar_url}
+									displayName={prefs.data()?.name}
+									userId={user()?.id || ""}
+								/>
 
-								<div>
-									<p class="mb-2 block font-medium text-gray-700 text-sm">
-										{t("settings.streamingPlatforms")}
-									</p>
-
-									<Show
-										fallback={
-											<div class="space-y-2">
-												<For each={[1, 2]}>
-													{() => (
-														<div class="flex items-center justify-between rounded-lg border border-gray-200 p-3">
-															<div class="flex items-center space-x-3">
-																<Skeleton class="h-10 w-10 rounded-lg" />
-																<div class="space-y-1">
-																	<Skeleton class="h-4 w-20" />
-																	<Skeleton class="h-3 w-16" />
-																</div>
-															</div>
-															<Skeleton class="h-8 w-20 rounded-lg" />
-														</div>
-													)}
-												</For>
-											</div>
-										}
-										when={!streamingAccounts.isLoading()}>
-										<Show when={streamingAccounts.data().length > 0}>
-											<div class="mb-4 space-y-3">
-												<For each={streamingAccounts.data()}>
-													{(account) => (
-														<StreamingAccountStats
-															data={{
-																platform: account.platform,
-																accountName:
-																	account.extra_data?.name ||
-																	account.extra_data?.nickname ||
-																	account.platform,
-																accountImage: account.extra_data?.image || null,
-																sponsorCount: account.sponsor_count,
-																viewsLast30d: account.views_last_30d,
-																followerCount: account.follower_count,
-																uniqueViewersLast30d:
-																	account.unique_viewers_last_30d,
-																statsLastRefreshedAt:
-																	account.stats_last_refreshed_at,
-															}}
-															onDisconnect={() =>
-																handleDisconnectAccount(account.platform)
-															}
-															onRefresh={() =>
-																handleRefreshStats(account.platform)
-															}
-														/>
-													)}
-												</For>
-											</div>
-										</Show>
-
-										<div class="space-y-2">
-											<For each={availablePlatforms}>
-												{(platform) => (
-													<Show
-														when={
-															!connectedPlatforms().has(platform.targetPlatform)
-														}>
-														<div class="flex items-center justify-between rounded-lg border border-gray-200 p-3">
-															<div class="flex items-center space-x-3">
-																<div
-																	class={`h-10 w-10 bg-linear-to-r ${platform.color} flex items-center justify-center rounded-lg`}>
-																	<span class="font-bold text-sm text-white">
-																		{platform.name[0]}
-																	</span>
-																</div>
-																<div>
-																	<p class="font-medium text-gray-900">
-																		{platform.name}
-																	</p>
-																	<p class="text-gray-500 text-sm">
-																		{t("settings.notConnected")}
-																	</p>
-																</div>
-															</div>
-															<Button
-																as="a"
-																href={apiRoutes.streaming.connect(
-																	platform.platform,
-																)}
-																size="sm">
-																{t("settings.connect")}
-															</Button>
-														</div>
-													</Show>
-												)}
-											</For>
-										</div>
-									</Show>
-								</div>
+								{/* Platform Connections */}
+								<PlatformConnectionsPanel
+									accounts={streamingAccounts.data()}
+									isLoading={streamingAccounts.isLoading()}
+									userId={user()?.id || ""}
+								/>
 							</div>
 						</div>
 
+						{/* Language Settings */}
 						<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
 							<h3 class="mb-6 font-medium text-gray-900 text-lg">
 								{t("settings.language")}
@@ -923,6 +330,7 @@ export default function Settings() {
 							</div>
 						</div>
 
+						{/* Donation Page */}
 						<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
 							<h3 class="mb-6 font-medium text-gray-900 text-lg">
 								{t("settings.donationPage")}
@@ -996,575 +404,26 @@ export default function Settings() {
 							</div>
 						</div>
 
-						<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-							<h3 class="mb-6 font-medium text-gray-900 text-lg">
-								{t("settings.donationSettings")}
-							</h3>
-							<form class="space-y-4" onSubmit={handleSaveDonationSettings}>
-								<div class="grid gap-4 md:grid-cols-3">
-									<div>
-										<label class="block font-medium text-gray-700 text-sm">
-											{t("settings.minimumAmount")}
-											<div class="relative mt-2">
-												<div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-													<span class="text-gray-500 text-sm">
-														{currency()}
-													</span>
-												</div>
-												<input
-													class="w-full rounded-lg border border-gray-300 py-2 pr-3 pl-12 text-sm focus:border-transparent focus:ring-2 focus:ring-purple-500"
-													onInput={(e) => {
-														const val = e.currentTarget.value;
-														setMinAmount(val ? parseInt(val, 10) : null);
-													}}
-													placeholder={t("settings.noMinimum")}
-													type="number"
-													value={minAmount() ?? ""}
-												/>
-											</div>
-										</label>
-										<p class="mt-1 text-gray-500 text-xs">
-											{t("settings.leaveEmptyNoMin")}
-										</p>
-									</div>
+						{/* Donation Settings Form */}
+						<DonationSettingsForm
+							initialCurrency={prefs.data()?.donation_currency}
+							initialDefaultVoice={prefs.data()?.default_voice}
+							initialMaxAmount={prefs.data()?.max_donation_amount}
+							initialMinAmount={prefs.data()?.min_donation_amount}
+							userId={user()?.id || ""}
+						/>
 
-									<div>
-										<label class="block font-medium text-gray-700 text-sm">
-											{t("settings.maximumAmount")}
-											<div class="relative mt-2">
-												<div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-													<span class="text-gray-500 text-sm">
-														{currency()}
-													</span>
-												</div>
-												<input
-													class="w-full rounded-lg border border-gray-300 py-2 pr-3 pl-12 text-sm focus:border-transparent focus:ring-2 focus:ring-purple-500"
-													onInput={(e) => {
-														const val = e.currentTarget.value;
-														setMaxAmount(val ? parseInt(val, 10) : null);
-													}}
-													placeholder={t("settings.noMaximum")}
-													type="number"
-													value={maxAmount() ?? ""}
-												/>
-											</div>
-										</label>
-										<p class="mt-1 text-gray-500 text-xs">
-											{t("settings.leaveEmptyNoMax")}
-										</p>
-									</div>
+						{/* User Roles Management */}
+						<UserRolesManagement
+							isLoading={loadingRoles()}
+							myRoles={myRoles()}
+							pendingInvitations={pendingInvitations()}
+							pendingInvitationsSent={pendingInvitationsSent()}
+							rolesIGranted={rolesIGranted()}
+							userId={user()?.id || ""}
+						/>
 
-									<div>
-										<label class="block font-medium text-gray-700 text-sm">
-											{t("settings.currency")}
-											<select
-												class="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-purple-500"
-												onChange={(e) => setCurrency(e.currentTarget.value)}
-												value={currency()}>
-												<For each={currencies}>
-													{(curr) => <option value={curr}>{curr}</option>}
-												</For>
-											</select>
-										</label>
-									</div>
-								</div>
-
-								<div>
-									<label class="block font-medium text-gray-700 text-sm">
-										{t("settings.defaultTtsVoice")}
-										<select
-											class="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-purple-500"
-											onChange={(e) => setDefaultVoice(e.currentTarget.value)}
-											value={defaultVoice()}>
-											<option value="random">
-												{t("settings.randomVoice")}
-											</option>
-											<option value="google_en_us_male">
-												Google TTS - English (US) Male
-											</option>
-											<option value="google_en_us_female">
-												Google TTS - English (US) Female
-											</option>
-										</select>
-									</label>
-									<p class="mt-1 text-gray-500 text-xs">
-										{t("settings.voiceHelp")}
-									</p>
-								</div>
-
-								<div class="flex items-start space-x-3 rounded-lg bg-blue-50 p-3">
-									<svg
-										aria-hidden="true"
-										class="mt-0.5 h-5 w-5 shrink-0 text-blue-500"
-										fill="none"
-										stroke="currentColor"
-										viewBox="0 0 24 24">
-										<path
-											d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											stroke-width="2"
-										/>
-									</svg>
-									<div class="text-blue-800 text-sm">
-										<p class="mb-1 font-medium">
-											{t("settings.donationLimitsInfo")}
-										</p>
-										<ul class="space-y-1 text-blue-700">
-											<li>• {t("settings.donationLimitsItem1")}</li>
-											<li>• {t("settings.donationLimitsItem2")}</li>
-											<li>• {t("settings.donationLimitsItem3")}</li>
-											<li>• {t("settings.donationLimitsItem4")}</li>
-										</ul>
-									</div>
-								</div>
-
-								<div class="flex items-center gap-4 pt-4">
-									<button
-										class={`rounded-lg bg-purple-600 px-4 py-2 font-medium text-sm text-white transition-colors ${
-											isSavingSettings()
-												? "cursor-not-allowed opacity-50"
-												: "hover:bg-purple-700"
-										}`}
-										disabled={isSavingSettings()}
-										type="submit">
-										{isSavingSettings()
-											? t("settings.saving")
-											: t("settings.saveDonationSettings")}
-									</button>
-									<Show when={saveSuccess()}>
-										<span class="text-green-600 text-sm">
-											{t("settings.settingsSaved")}
-										</span>
-									</Show>
-									<Show when={saveError()}>
-										<span class="text-red-600 text-sm">{saveError()}</span>
-									</Show>
-								</div>
-							</form>
-						</div>
-
-						<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-							<h3 class="mb-6 font-medium text-gray-900 text-lg">
-								{t("settings.roleInvitations")}
-							</h3>
-							<Show
-								fallback={
-									<div class="py-8 text-center text-gray-500">
-										<svg
-											aria-hidden="true"
-											class="mx-auto mb-3 h-12 w-12 text-gray-400"
-											fill="none"
-											stroke="currentColor"
-											viewBox="0 0 24 24">
-											<path
-												d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												stroke-width="2"
-											/>
-										</svg>
-										<p class="text-sm">{t("settings.noPendingInvitations")}</p>
-										<p class="mt-1 text-gray-400 text-xs">
-											{t("settings.invitationsHelp")}
-										</p>
-									</div>
-								}
-								when={!loadingRoles() && pendingInvitations().length > 0}>
-								<div class="space-y-3">
-									<For each={pendingInvitations()}>
-										{(invitation) => {
-											const granterInfo = () =>
-												getUserInfo_cached(invitation.granter_id);
-											return (
-												<div class="flex items-center justify-between rounded-lg border border-gray-200 p-4">
-													<div class="flex items-center gap-3">
-														<div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-purple-500 to-pink-500">
-															<Show
-																fallback={
-																	<span class="font-bold text-white">
-																		{granterInfo()?.name?.[0]?.toUpperCase() ||
-																			"?"}
-																	</span>
-																}
-																when={granterInfo()?.displayAvatar}>
-																<img
-																	alt={granterInfo()?.name || "User"}
-																	class="h-full w-full object-cover"
-																	src={granterInfo()?.displayAvatar ?? ""}
-																/>
-															</Show>
-														</div>
-														<div>
-															<p class="font-medium text-gray-900">
-																{granterInfo()?.name || "Loading..."}
-															</p>
-															<p class="text-gray-500 text-sm">
-																{t("settings.invitedYouAs")}{" "}
-																<span class="font-medium text-purple-600">
-																	{formatRoleType(invitation.role_type)}
-																</span>
-															</p>
-															<p class="text-gray-400 text-xs">
-																{formatDate(invitation.granted_at)}
-															</p>
-														</div>
-													</div>
-													<div class="flex gap-2">
-														<button
-															class="rounded-lg bg-green-600 px-3 py-1.5 font-medium text-sm text-white transition-colors hover:bg-green-700 disabled:opacity-50"
-															disabled={processingRoleId() === invitation.id}
-															onClick={() =>
-																handleAcceptInvitation(invitation.id)
-															}
-															type="button">
-															{processingRoleId() === invitation.id
-																? "..."
-																: t("settings.accept")}
-														</button>
-														<button
-															class="rounded-lg bg-gray-200 px-3 py-1.5 font-medium text-gray-700 text-sm transition-colors hover:bg-gray-300 disabled:opacity-50"
-															disabled={processingRoleId() === invitation.id}
-															onClick={() =>
-																handleDeclineInvitation(invitation.id)
-															}
-															type="button">
-															{t("settings.decline")}
-														</button>
-													</div>
-												</div>
-											);
-										}}
-									</For>
-								</div>
-							</Show>
-						</div>
-
-						<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-							<h3 class="mb-6 font-medium text-gray-900 text-lg">
-								{t("settings.myRolesInChannels")}
-							</h3>
-							<Show
-								fallback={
-									<div class="py-8 text-center text-gray-500">
-										<svg
-											aria-hidden="true"
-											class="mx-auto mb-3 h-12 w-12 text-gray-400"
-											fill="none"
-											stroke="currentColor"
-											viewBox="0 0 24 24">
-											<path
-												d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												stroke-width="2"
-											/>
-										</svg>
-										<p class="text-sm">{t("settings.noRolesInChannels")}</p>
-										<p class="mt-1 text-gray-400 text-xs">
-											{t("settings.rolesGrantedHelp")}
-										</p>
-									</div>
-								}
-								when={!loadingRoles() && myRoles().length > 0}>
-								<div class="space-y-3">
-									<For each={myRoles()}>
-										{(role) => {
-											const granterInfo = () =>
-												getUserInfo_cached(role.granter_id);
-											return (
-												<div class="flex items-center justify-between rounded-lg border border-gray-200 p-4">
-													<div class="flex items-center gap-3">
-														<div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-purple-500 to-pink-500">
-															<Show
-																fallback={
-																	<span class="font-bold text-white">
-																		{granterInfo()?.name?.[0]?.toUpperCase() ||
-																			"?"}
-																	</span>
-																}
-																when={granterInfo()?.displayAvatar}>
-																<img
-																	alt={granterInfo()?.name || "User"}
-																	class="h-full w-full object-cover"
-																	src={granterInfo()?.displayAvatar ?? ""}
-																/>
-															</Show>
-														</div>
-														<div>
-															<p class="font-medium text-gray-900">
-																{granterInfo()?.name || "Loading..."}
-																{t("settings.channel")}
-															</p>
-															<p class="text-gray-500 text-sm">
-																<span class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 font-medium text-purple-800 text-xs">
-																	{formatRoleType(role.role_type)}
-																</span>
-															</p>
-															<p class="mt-1 text-gray-400 text-xs">
-																{t("settings.since")}{" "}
-																{formatDate(
-																	role.accepted_at || role.granted_at,
-																)}
-															</p>
-														</div>
-													</div>
-												</div>
-											);
-										}}
-									</For>
-								</div>
-							</Show>
-						</div>
-
-						<div class="relative">
-							<div class="absolute inset-0 flex items-center">
-								<div class="w-full border-gray-300 border-t"></div>
-							</div>
-							<div class="relative flex justify-center text-sm">
-								<span class="bg-gray-50 px-2 text-gray-500">
-									{t("settings.channelManagement")}
-								</span>
-							</div>
-						</div>
-
-						<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-							<h3 class="mb-6 font-medium text-gray-900 text-lg">
-								{t("settings.roleManagement")}
-							</h3>
-
-							<div class="mb-6 rounded-lg bg-gray-50 p-4">
-								<h4 class="mb-3 font-medium text-gray-900">
-									{t("settings.inviteUser")}
-								</h4>
-								<form class="space-y-3" onSubmit={handleInviteUser}>
-									<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-										<div>
-											<input
-												class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
-												onInput={(e) =>
-													setInviteUsername(e.currentTarget.value)
-												}
-												placeholder={t("settings.enterUsername")}
-												type="text"
-												value={inviteUsername()}
-											/>
-										</div>
-										<div>
-											<select
-												class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
-												onChange={(e) =>
-													setInviteRoleType(
-														e.currentTarget.value as "moderator" | "manager",
-													)
-												}
-												value={inviteRoleType()}>
-												<option value="moderator">
-													{t("settings.moderator")}
-												</option>
-												<option value="manager">{t("settings.manager")}</option>
-											</select>
-										</div>
-										<div>
-											<button
-												class={`w-full rounded-lg bg-purple-600 px-4 py-2 font-medium text-sm text-white transition-colors ${
-													isInviting()
-														? "cursor-not-allowed opacity-50"
-														: "hover:bg-purple-700"
-												}`}
-												disabled={isInviting()}
-												type="submit">
-												{isInviting()
-													? t("settings.sending")
-													: t("settings.sendInvitation")}
-											</button>
-										</div>
-									</div>
-									<Show when={inviteError()}>
-										<p class="text-red-600 text-sm">{inviteError()}</p>
-									</Show>
-									<Show when={inviteSuccess()}>
-										<p class="text-green-600 text-sm">
-											{t("settings.invitationSent")}
-										</p>
-									</Show>
-								</form>
-								<div class="mt-3 rounded-lg bg-blue-50 p-3">
-									<div class="flex">
-										<svg
-											aria-hidden="true"
-											class="mr-2 h-5 w-5 shrink-0 text-blue-500"
-											fill="none"
-											stroke="currentColor"
-											viewBox="0 0 24 24">
-											<path
-												d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												stroke-width="2"
-											/>
-										</svg>
-										<div class="text-blue-800 text-sm">
-											<p class="font-medium">{t("settings.rolePermissions")}</p>
-											<ul class="mt-1 space-y-1 text-blue-700 text-xs">
-												<li>
-													• <strong>{t("settings.moderator")}:</strong>{" "}
-													{t("settings.moderatorDesc")}
-												</li>
-												<li>
-													• <strong>{t("settings.manager")}:</strong>{" "}
-													{t("settings.managerDesc")}
-												</li>
-											</ul>
-										</div>
-									</div>
-								</div>
-							</div>
-
-							<Show
-								when={!loadingRoles() && pendingInvitationsSent().length > 0}>
-								<div class="mb-6 space-y-3">
-									<h4 class="font-medium text-gray-700 text-sm">
-										{t("settings.pendingInvitations")}
-									</h4>
-									<For each={pendingInvitationsSent()}>
-										{(role) => {
-											const userInfo = () => getUserInfo_cached(role.user_id);
-											return (
-												<div class="flex items-center justify-between rounded-lg border border-yellow-200 bg-yellow-50 p-4">
-													<div class="flex items-center gap-3">
-														<div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-yellow-400 to-orange-400">
-															<Show
-																fallback={
-																	<span class="font-bold text-white">
-																		{userInfo()?.name?.[0]?.toUpperCase() ||
-																			"?"}
-																	</span>
-																}
-																when={userInfo()?.displayAvatar}>
-																<img
-																	alt={userInfo()?.name || "User"}
-																	class="h-full w-full object-cover"
-																	src={userInfo()?.displayAvatar ?? ""}
-																/>
-															</Show>
-														</div>
-														<div>
-															<p class="font-medium text-gray-900">
-																{userInfo()?.name || "Loading..."}
-															</p>
-															<p class="text-gray-500 text-sm">
-																<span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 font-medium text-xs text-yellow-800">
-																	{formatRoleType(role.role_type)} (
-																	{t("settings.pending")})
-																</span>
-															</p>
-															<p class="mt-1 text-gray-400 text-xs">
-																Invited {formatDate(role.granted_at)}
-															</p>
-														</div>
-													</div>
-													<button
-														class="rounded-lg px-3 py-1.5 font-medium text-red-600 text-sm transition-colors hover:bg-red-50 disabled:opacity-50"
-														disabled={processingRoleId() === role.id}
-														onClick={() => handleRevokeRole(role.id)}
-														type="button">
-														{processingRoleId() === role.id
-															? "..."
-															: t("settings.cancel")}
-													</button>
-												</div>
-											);
-										}}
-									</For>
-								</div>
-							</Show>
-
-							<Show
-								fallback={
-									<Show when={pendingInvitationsSent().length === 0}>
-										<div class="py-8 text-center text-gray-500">
-											<svg
-												aria-hidden="true"
-												class="mx-auto mb-3 h-12 w-12 text-gray-400"
-												fill="none"
-												stroke="currentColor"
-												viewBox="0 0 24 24">
-												<path
-													d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width="2"
-												/>
-											</svg>
-											<p class="text-sm">{t("settings.noRolesGranted")}</p>
-											<p class="mt-1 text-gray-400 text-xs">
-												{t("settings.rolesGrantedToHelp")}
-											</p>
-										</div>
-									</Show>
-								}
-								when={!loadingRoles() && rolesIGranted().length > 0}>
-								<div class="space-y-3">
-									<h4 class="font-medium text-gray-700 text-sm">
-										{t("settings.yourTeam")}
-									</h4>
-									<For each={rolesIGranted()}>
-										{(role) => {
-											const userInfo = () => getUserInfo_cached(role.user_id);
-											return (
-												<div class="flex items-center justify-between rounded-lg border border-gray-200 p-4">
-													<div class="flex items-center gap-3">
-														<div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-linear-to-r from-purple-500 to-pink-500">
-															<Show
-																fallback={
-																	<span class="font-bold text-white">
-																		{userInfo()?.name?.[0]?.toUpperCase() ||
-																			"?"}
-																	</span>
-																}
-																when={userInfo()?.displayAvatar}>
-																<img
-																	alt={userInfo()?.name || "User"}
-																	class="h-full w-full object-cover"
-																	src={userInfo()?.displayAvatar ?? ""}
-																/>
-															</Show>
-														</div>
-														<div>
-															<p class="font-medium text-gray-900">
-																{userInfo()?.name || "Loading..."}
-															</p>
-															<p class="text-gray-500 text-sm">
-																<span class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 font-medium text-purple-800 text-xs">
-																	{formatRoleType(role.role_type)}
-																</span>
-															</p>
-															<p class="mt-1 text-gray-400 text-xs">
-																{t("settings.since")}{" "}
-																{formatDate(
-																	role.accepted_at || role.granted_at,
-																)}
-															</p>
-														</div>
-													</div>
-													<button
-														class="rounded-lg px-3 py-1.5 font-medium text-red-600 text-sm transition-colors hover:bg-red-50 disabled:opacity-50"
-														disabled={processingRoleId() === role.id}
-														onClick={() => handleRevokeRole(role.id)}
-														type="button">
-														{processingRoleId() === role.id
-															? "..."
-															: t("settings.revoke")}
-													</button>
-												</div>
-											);
-										}}
-									</For>
-								</div>
-							</Show>
-						</div>
-
+						{/* Notification Preferences */}
 						<Show when={user()}>
 							<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
 								<h3 class="mb-6 font-medium text-gray-900 text-lg">


### PR DESCRIPTION
## Summary

- Split the monolithic `dashboard/settings.tsx` (1,613 lines) into smaller, focused components
- Created 4 new component files in `frontend/src/components/settings/`:
  - `AvatarUploadSection.tsx` (186 lines) - Avatar upload logic and UI
  - `DonationSettingsForm.tsx` (210 lines) - Donation configuration form  
  - `PlatformConnectionsPanel.tsx` (184 lines) - Streaming platform connections
  - `UserRolesManagement.tsx` (644 lines) - Role management UI
- Main `settings.tsx` reduced to 472 lines (composition only), under 500 line target
- All existing functionality preserved

## Test plan

- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] Code formatting validated (`lefthook run pre-commit`)
- [x] App loads without errors (verified via Playwright)
- [ ] Manual verification of settings page functionality after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)