### PR TITLE
Implement widget registry pattern in SmartCanvasWidgetRenderer

### DIFF
--- a/frontend/src/components/SmartCanvasWidgetRenderer.tsx
+++ b/frontend/src/components/SmartCanvasWidgetRenderer.tsx
@@ -1,15 +1,4 @@
-import AlertboxWidget from "./widgets/AlertboxWidget";
-import ChatWidget from "./widgets/ChatWidget";
-import DonationGoalWidget from "./widgets/DonationGoalWidget";
-import EventListWidget from "./widgets/EventListWidget";
-import FollowerCountWidget from "./widgets/FollowerCountWidget";
-import GiveawayWidget from "./widgets/GiveawayWidget";
-import PlaceholderWidget from "./widgets/PlaceholderWidget";
-import PollWidget from "./widgets/PollWidget";
-import SliderWidget from "./widgets/SliderWidget";
-import TimerWidget from "./widgets/TimerWidget";
-import TopDonorsWidget from "./widgets/TopDonorsWidget";
-import ViewerCountWidget from "./widgets/ViewerCountWidget";
+import { renderWidget } from "./widgetRegistry";
 
 interface CanvasWidget {
 	id: string;
@@ -25,163 +14,24 @@ interface WidgetRendererProps {
 	widget: CanvasWidget;
 }
 
-// Widget config defaults - these are merged with user configs at runtime
-// Using explicit type for the record since configs are dynamically merged
-const DEFAULT_CONFIGS: Record<string, Record<string, unknown>> = {
-	placeholder: {
-		message: "Placeholder Widget",
-		fontSize: 24,
-		textColor: "#ffffff",
-		backgroundColor: "#9333ea",
-		borderColor: "#ffffff",
-		borderWidth: 2,
-		padding: 16,
-		borderRadius: 8,
-	},
-	"viewer-count": {
-		label: "viewers",
-		fontSize: 32,
-		textColor: "#ffffff",
-		backgroundColor: "#8b5cf6",
-		showIcon: true,
-	},
-	"follower-count": {
-		label: "followers",
-		fontSize: 32,
-		textColor: "#ffffff",
-		backgroundColor: "#ec4899",
-		showIcon: true,
-	},
-	timer: {
-		duration: 300,
-		fontSize: 48,
-		textColor: "#ffffff",
-		backgroundColor: "#3b82f6",
-		showLabel: true,
-		label: "Time Remaining",
-	},
-	chat: {
-		maxMessages: 10,
-		fontSize: 16,
-		backgroundColor: "rgba(0, 0, 0, 0.8)",
-		textColor: "#ffffff",
-		showAvatars: true,
-	},
-	eventlist: {
-		maxEvents: 5,
-		fontSize: 16,
-		backgroundColor: "rgba(0, 0, 0, 0.8)",
-		textColor: "#ffffff",
-		showIcons: true,
-	},
-	topdonors: {
-		maxDonors: 5,
-		fontSize: 18,
-		backgroundColor: "rgba(0, 0, 0, 0.9)",
-		textColor: "#ffffff",
-		showRank: true,
-	},
-	alertbox: {
-		duration: 5,
-		fontSize: 32,
-		backgroundColor: "#8b5cf6",
-		textColor: "#ffffff",
-		soundEnabled: true,
-	},
-	poll: {
-		question: "What should we play next?",
-		options: ["Game 1", "Game 2", "Game 3"],
-		fontSize: 20,
-		backgroundColor: "rgba(0, 0, 0, 0.9)",
-		textColor: "#ffffff",
-	},
-	giveaway: {
-		title: "Giveaway!",
-		prize: "Amazing Prize",
-		fontSize: 24,
-		backgroundColor: "#ec4899",
-		textColor: "#ffffff",
-	},
-	slider: {
-		slides: [
-			{ text: "Slide 1", duration: 5 },
-			{ text: "Slide 2", duration: 5 },
-		],
-		fontSize: 24,
-		backgroundColor: "#8b5cf6",
-		textColor: "#ffffff",
-	},
-	"donation-goal": {
-		goal: 1000,
-		current: 450,
-		title: "Support the Stream!",
-		fontSize: 24,
-		backgroundColor: "#10b981",
-		textColor: "#ffffff",
-		showPercentage: true,
-	},
-};
-
 export default function SmartCanvasWidgetRenderer(props: WidgetRendererProps) {
-	const getConfig = <T,>(): T => {
-		const defaultConfig = DEFAULT_CONFIGS[props.widget.widgetType] || {};
-		return { ...defaultConfig, ...props.widget.config } as T;
-	};
-
 	const renderWidgetContent = () => {
-		switch (props.widget.widgetType) {
-			case "placeholder":
-				return <PlaceholderWidget config={getConfig()} />;
+		const rendered = renderWidget(props.widget.widgetType, props.widget.config);
 
-			case "viewer-count":
-				return <ViewerCountWidget config={getConfig()} data={null} />;
-
-			case "follower-count":
-				return (
-					<FollowerCountWidget
-						config={getConfig()}
-						count={Math.floor(Math.random() * 10000)}
-					/>
-				);
-
-			case "timer":
-				return <TimerWidget config={getConfig()} />;
-
-			case "chat":
-				return <ChatWidget config={getConfig()} messages={[]} />;
-
-			case "eventlist":
-				return <EventListWidget config={getConfig()} events={[]} />;
-
-			case "topdonors":
-				return <TopDonorsWidget config={getConfig()} donors={[]} />;
-
-			case "alertbox":
-				return <AlertboxWidget config={getConfig()} event={null} />;
-
-			case "poll":
-				return <PollWidget config={getConfig()} />;
-
-			case "giveaway":
-				return <GiveawayWidget config={getConfig()} />;
-
-			case "slider":
-				return <SliderWidget config={getConfig()} />;
-
-			case "donation-goal":
-				return <DonationGoalWidget config={getConfig()} currentAmount={0} />;
-
-			default:
-				return (
-					<div class="flex h-full w-full items-center justify-center rounded-lg border-2 border-white/20 bg-linear-to-br from-gray-500 to-gray-700 p-4 text-white shadow-lg">
-						<div class="text-center">
-							<div class="mb-2 text-4xl">❓</div>
-							<div class="font-semibold">Unknown Widget</div>
-							<div class="text-sm opacity-80">{props.widget.widgetType}</div>
-						</div>
-					</div>
-				);
+		if (rendered) {
+			return rendered;
 		}
+
+		// Fallback for unknown widget types
+		return (
+			<div class="flex h-full w-full items-center justify-center rounded-lg border-2 border-white/20 bg-linear-to-br from-gray-500 to-gray-700 p-4 text-white shadow-lg">
+				<div class="text-center">
+					<div class="mb-2 text-4xl">&#x2753;</div>
+					<div class="font-semibold">Unknown Widget</div>
+					<div class="text-sm opacity-80">{props.widget.widgetType}</div>
+				</div>
+			</div>
+		);
 	};
 
 	return (

--- a/frontend/src/components/widgetRegistry.tsx
+++ b/frontend/src/components/widgetRegistry.tsx
@@ -1,0 +1,238 @@
+import type { JSX } from "solid-js";
+import AlertboxWidget from "./widgets/AlertboxWidget";
+import ChatWidget from "./widgets/ChatWidget";
+import DonationGoalWidget from "./widgets/DonationGoalWidget";
+import EventListWidget from "./widgets/EventListWidget";
+import FollowerCountWidget from "./widgets/FollowerCountWidget";
+import GiveawayWidget from "./widgets/GiveawayWidget";
+import PlaceholderWidget from "./widgets/PlaceholderWidget";
+import PollWidget from "./widgets/PollWidget";
+import SliderWidget from "./widgets/SliderWidget";
+import TimerWidget from "./widgets/TimerWidget";
+import TopDonorsWidget from "./widgets/TopDonorsWidget";
+import ViewerCountWidget from "./widgets/ViewerCountWidget";
+
+/**
+ * Widget Registry Pattern
+ *
+ * This module implements a registry pattern for stream widgets, following the
+ * open/closed principle. To add a new widget:
+ *
+ * 1. Create your widget component in ./widgets/
+ * 2. Import it here
+ * 3. Add an entry to WIDGET_REGISTRY with:
+ *    - defaultConfig: Default configuration values
+ *    - render: Function that creates the component with merged config
+ *
+ * The SmartCanvasWidgetRenderer will automatically pick up new widgets
+ * without requiring any modifications.
+ */
+
+// Type for widget configuration - configs are merged at runtime
+type WidgetConfig = Record<string, unknown>;
+
+// Registry entry type - each widget has a default config and render function
+interface WidgetRegistryEntry {
+	defaultConfig: WidgetConfig;
+	render: (config: WidgetConfig) => JSX.Element;
+}
+
+/**
+ * Central registry of all available widgets.
+ * Each entry contains default configuration and a render function.
+ *
+ * To add a new widget, simply add a new entry here - no other files need modification.
+ */
+export const WIDGET_REGISTRY: Record<string, WidgetRegistryEntry> = {
+	placeholder: {
+		defaultConfig: {
+			message: "Placeholder Widget",
+			fontSize: 24,
+			textColor: "#ffffff",
+			backgroundColor: "#9333ea",
+			borderColor: "#ffffff",
+			borderWidth: 2,
+			padding: 16,
+			borderRadius: 8,
+		},
+		render: (config) => <PlaceholderWidget config={config as never} />,
+	},
+
+	"viewer-count": {
+		defaultConfig: {
+			label: "viewers",
+			fontSize: 32,
+			textColor: "#ffffff",
+			backgroundColor: "#8b5cf6",
+			showIcon: true,
+		},
+		render: (config) => (
+			<ViewerCountWidget config={config as never} data={null} />
+		),
+	},
+
+	"follower-count": {
+		defaultConfig: {
+			label: "followers",
+			fontSize: 32,
+			textColor: "#ffffff",
+			backgroundColor: "#ec4899",
+			showIcon: true,
+		},
+		render: (config) => (
+			<FollowerCountWidget
+				config={config as never}
+				count={Math.floor(Math.random() * 10000)}
+			/>
+		),
+	},
+
+	timer: {
+		defaultConfig: {
+			duration: 300,
+			fontSize: 48,
+			textColor: "#ffffff",
+			backgroundColor: "#3b82f6",
+			showLabel: true,
+			label: "Time Remaining",
+		},
+		render: (config) => <TimerWidget config={config as never} />,
+	},
+
+	chat: {
+		defaultConfig: {
+			maxMessages: 10,
+			fontSize: 16,
+			backgroundColor: "rgba(0, 0, 0, 0.8)",
+			textColor: "#ffffff",
+			showAvatars: true,
+		},
+		render: (config) => <ChatWidget config={config as never} messages={[]} />,
+	},
+
+	eventlist: {
+		defaultConfig: {
+			maxEvents: 5,
+			fontSize: 16,
+			backgroundColor: "rgba(0, 0, 0, 0.8)",
+			textColor: "#ffffff",
+			showIcons: true,
+		},
+		render: (config) => (
+			<EventListWidget config={config as never} events={[]} />
+		),
+	},
+
+	topdonors: {
+		defaultConfig: {
+			maxDonors: 5,
+			fontSize: 18,
+			backgroundColor: "rgba(0, 0, 0, 0.9)",
+			textColor: "#ffffff",
+			showRank: true,
+		},
+		render: (config) => (
+			<TopDonorsWidget config={config as never} donors={[]} />
+		),
+	},
+
+	alertbox: {
+		defaultConfig: {
+			duration: 5,
+			fontSize: 32,
+			backgroundColor: "#8b5cf6",
+			textColor: "#ffffff",
+			soundEnabled: true,
+		},
+		render: (config) => (
+			<AlertboxWidget config={config as never} event={null} />
+		),
+	},
+
+	poll: {
+		defaultConfig: {
+			question: "What should we play next?",
+			options: ["Game 1", "Game 2", "Game 3"],
+			fontSize: 20,
+			backgroundColor: "rgba(0, 0, 0, 0.9)",
+			textColor: "#ffffff",
+		},
+		render: (config) => <PollWidget config={config as never} />,
+	},
+
+	giveaway: {
+		defaultConfig: {
+			title: "Giveaway!",
+			prize: "Amazing Prize",
+			fontSize: 24,
+			backgroundColor: "#ec4899",
+			textColor: "#ffffff",
+		},
+		render: (config) => <GiveawayWidget config={config as never} />,
+	},
+
+	slider: {
+		defaultConfig: {
+			slides: [
+				{ text: "Slide 1", duration: 5 },
+				{ text: "Slide 2", duration: 5 },
+			],
+			fontSize: 24,
+			backgroundColor: "#8b5cf6",
+			textColor: "#ffffff",
+		},
+		render: (config) => <SliderWidget config={config as never} />,
+	},
+
+	"donation-goal": {
+		defaultConfig: {
+			goal: 1000,
+			current: 450,
+			title: "Support the Stream!",
+			fontSize: 24,
+			backgroundColor: "#10b981",
+			textColor: "#ffffff",
+			showPercentage: true,
+		},
+		render: (config) => (
+			<DonationGoalWidget config={config as never} currentAmount={0} />
+		),
+	},
+};
+
+/**
+ * Get all registered widget types
+ */
+export function getRegisteredWidgetTypes(): string[] {
+	return Object.keys(WIDGET_REGISTRY);
+}
+
+/**
+ * Check if a widget type is registered
+ */
+export function isWidgetRegistered(widgetType: string): boolean {
+	return widgetType in WIDGET_REGISTRY;
+}
+
+/**
+ * Get the default config for a widget type
+ */
+export function getDefaultConfig(widgetType: string): WidgetConfig | null {
+	return WIDGET_REGISTRY[widgetType]?.defaultConfig ?? null;
+}
+
+/**
+ * Render a widget by type with merged configuration
+ */
+export function renderWidget(
+	widgetType: string,
+	userConfig?: WidgetConfig,
+): JSX.Element | null {
+	const entry = WIDGET_REGISTRY[widgetType];
+	if (!entry) {
+		return null;
+	}
+
+	const mergedConfig = { ...entry.defaultConfig, ...userConfig };
+	return entry.render(mergedConfig);
+}


### PR DESCRIPTION
## Summary
- Refactors `SmartCanvasWidgetRenderer` to follow the open/closed principle by introducing a centralized widget registry pattern
- Creates `widgetRegistry.tsx` with `WIDGET_REGISTRY` containing all widget definitions (defaultConfig + render function)
- Simplifies `SmartCanvasWidgetRenderer` from 202 lines to 52 lines
- Adding new widgets now only requires modifying `widgetRegistry.tsx` - no changes needed to the renderer

## Changes
- **New file**: `frontend/src/components/widgetRegistry.tsx`
  - Central registry with all 12 widget types
  - Helper functions: `getRegisteredWidgetTypes()`, `isWidgetRegistered()`, `getDefaultConfig()`, `renderWidget()`
  - Clear documentation on how to add new widgets
  
- **Refactored**: `frontend/src/components/SmartCanvasWidgetRenderer.tsx`
  - Removed hardcoded `DEFAULT_CONFIGS` object
  - Removed large switch/case statement
  - Now simply imports and uses `renderWidget()` from registry

## Test plan
- [x] TypeScript type checking passes (`bun run typecheck`)
- [x] Frontend tests pass (`bun test`)
- [x] Frontend build succeeds (`bun run build`)
- [x] Pre-commit hooks pass (`lefthook run pre-commit`)
- [ ] Manual verification: Add widgets to Smart Canvas and confirm they render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)