### PR TITLE
[LOW][I18N] Localize hardcoded strings in dashboard viewers page

### DIFF
--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -135,6 +135,11 @@ export const dict: Dictionary = {
 		searchPlaceholder: "Nachrichten suchen...",
 	},
 
+	// Viewers page
+	viewers: {
+		searchPlaceholder: "Nach Anzeigename suchen...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Stream-Statistiken",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -133,6 +133,11 @@ export const dict = {
 		searchPlaceholder: "Search messages...",
 	},
 
+	// Viewers page
+	viewers: {
+		searchPlaceholder: "Search by display name...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Stream Analytics",

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -135,6 +135,11 @@ export const dict: Dictionary = {
 		searchPlaceholder: "Buscar mensajes...",
 	},
 
+	// Viewers page
+	viewers: {
+		searchPlaceholder: "Buscar por nombre...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Estadísticas de streams",

--- a/frontend/src/i18n/locales/pl.ts
+++ b/frontend/src/i18n/locales/pl.ts
@@ -135,6 +135,11 @@ export const dict: Dictionary = {
 		searchPlaceholder: "Szukaj wiadomości...",
 	},
 
+	// Viewers page
+	viewers: {
+		searchPlaceholder: "Szukaj po nazwie wyświetlanej...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Statystyki streamów",

--- a/frontend/src/routes/dashboard/viewers/index.tsx
+++ b/frontend/src/routes/dashboard/viewers/index.tsx
@@ -6,6 +6,7 @@ import Badge from "~/components/ui/Badge";
 import Button from "~/components/ui/Button";
 import Card from "~/components/ui/Card";
 import Input, { Select } from "~/components/ui/Input";
+import { useTranslation } from "~/i18n";
 import { getLoginUrl, useCurrentUser } from "~/lib/auth";
 import { listBannedViewers, listViewers, searchViewers } from "~/sdk/ash_rpc";
 import { text } from "~/styles/design-system";
@@ -123,6 +124,7 @@ interface BannedViewer {
 export default function Viewers() {
 	const { user, isLoading } = useCurrentUser();
 	const navigate = useNavigate();
+	const { t } = useTranslation();
 
 	const [viewMode, setViewMode] = createSignal<ViewMode>("viewers");
 	const [viewers, setViewers] = createSignal<Viewer[]>([]);
@@ -426,7 +428,7 @@ export default function Viewers() {
 												class="mt-2"
 												id="search-viewers"
 												onInput={(e) => setSearchInput(e.currentTarget.value)}
-												placeholder="Search by display name..."
+												placeholder={t("viewers.searchPlaceholder")}
 												type="text"
 												value={searchInput()}
 											/>


### PR DESCRIPTION
## Summary
- Add translation key `viewers.searchPlaceholder` to all 4 locale files (en, de, pl, es)
- Update viewers component to use `t()` function for the search input placeholder
- Previously hardcoded: "Search by display name..."

## Test plan
- [x] All locale tests pass (`bun test src/i18n/locales/locales.test.ts`)
- [x] TypeScript type checking passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)