### PR TITLE
[LOW][I18N] Localize hardcoded strings in chat-history page

### DIFF
--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -130,6 +130,11 @@ export const dict: Dictionary = {
 		streamDescriptionPlaceholder: "Beschreibe deinen Stream...",
 	},
 
+	// Chat History page
+	chatHistory: {
+		searchPlaceholder: "Nachrichten suchen...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Stream-Statistiken",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -128,6 +128,11 @@ export const dict = {
 		streamDescriptionPlaceholder: "Describe your stream...",
 	},
 
+	// Chat History page
+	chatHistory: {
+		searchPlaceholder: "Search messages...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Stream Analytics",

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -130,6 +130,11 @@ export const dict: Dictionary = {
 		streamDescriptionPlaceholder: "Describe tu stream...",
 	},
 
+	// Chat History page
+	chatHistory: {
+		searchPlaceholder: "Buscar mensajes...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Estadísticas de streams",

--- a/frontend/src/i18n/locales/pl.ts
+++ b/frontend/src/i18n/locales/pl.ts
@@ -130,6 +130,11 @@ export const dict: Dictionary = {
 		streamDescriptionPlaceholder: "Opisz swój stream...",
 	},
 
+	// Chat History page
+	chatHistory: {
+		searchPlaceholder: "Szukaj wiadomości...",
+	},
+
 	// Analytics page
 	analytics: {
 		title: "Statystyki streamów",

--- a/frontend/src/routes/dashboard/chat-history.tsx
+++ b/frontend/src/routes/dashboard/chat-history.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "~/components/ui";
 import Badge from "~/components/ui/Badge";
 import Card from "~/components/ui/Card";
 import Input, { Select } from "~/components/ui/Input";
+import { useTranslation } from "~/i18n";
 import { getLoginUrl, useCurrentUser } from "~/lib/auth";
 import { getChatHistory } from "~/sdk/ash_rpc";
 import { text } from "~/styles/design-system";
@@ -168,6 +169,7 @@ function ChatHistoryContent(props: {
 	setSearchInput: (s: string) => void;
 	handleSearch: (e: Event) => void;
 }) {
+	const { t } = useTranslation();
 	const [messages, setMessages] = createSignal<ChatMessage[]>([]);
 	const [_isLoading, setIsLoading] = createSignal(true);
 
@@ -283,7 +285,7 @@ function ChatHistoryContent(props: {
 								class="mt-2"
 								id="chat-search"
 								onInput={(e) => props.setSearchInput(e.currentTarget.value)}
-								placeholder="Search messages..."
+								placeholder={t("chatHistory.searchPlaceholder")}
 								type="text"
 								value={props.searchInput()}
 							/>


### PR DESCRIPTION
## Summary
- Add `chatHistory.searchPlaceholder` translation key to all 4 locale files (en, de, pl, es)
- Update `chat-history.tsx` to use `t()` function for "Search messages..." placeholder

## Test plan
- [x] All 4 locale files updated with matching keys
- [x] `bun test locales.test.ts` passes
- [x] TypeScript type check passes
- [x] pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)