### PR TITLE
[LOW][TEST] Replace Process.sleep() with proper async testing

### DIFF
--- a/test/streampai/livestream_manager/alert_queue_test.exs
+++ b/test/streampai/livestream_manager/alert_queue_test.exs
@@ -2,6 +2,8 @@ defmodule Streampai.LivestreamManager.AlertQueueTest do
   use ExUnit.Case, async: true
   use Mneme
 
+  import Streampai.TestHelpers, only: [assert_eventually: 1]
+
   alias Streampai.LivestreamManager.AlertQueue
 
   setup do
@@ -77,20 +79,18 @@ defmodule Streampai.LivestreamManager.AlertQueueTest do
       # Pause the queue
       AlertQueue.pause_queue(pid)
 
-      # Wait a moment for control command to process
-      Process.sleep(50)
-
-      status = AlertQueue.get_queue_status(pid)
-      assert status.queue_state == :paused
+      # Wait for control command to process
+      assert_eventually(fn ->
+        AlertQueue.get_queue_status(pid).queue_state == :paused
+      end)
 
       # Resume the queue
       AlertQueue.resume_queue(pid)
 
-      # Wait a moment for control command to process
-      Process.sleep(50)
-
-      status = AlertQueue.get_queue_status(pid)
-      assert status.queue_state == :playing
+      # Wait for control command to process
+      assert_eventually(fn ->
+        AlertQueue.get_queue_status(pid).queue_state == :playing
+      end)
     end
 
     test "skip command removes next event", %{queue_pid: pid} do
@@ -108,10 +108,9 @@ defmodule Streampai.LivestreamManager.AlertQueueTest do
       AlertQueue.skip_event(pid)
 
       # Wait for command to process
-      Process.sleep(50)
-
-      status_after = AlertQueue.get_queue_status(pid)
-      assert status_after.queue_length == 1
+      assert_eventually(fn ->
+        AlertQueue.get_queue_status(pid).queue_length == 1
+      end)
     end
 
     test "clear command removes all non-control events", %{queue_pid: pid} do
@@ -131,10 +130,9 @@ defmodule Streampai.LivestreamManager.AlertQueueTest do
       AlertQueue.clear_queue(pid)
 
       # Wait for command to process
-      Process.sleep(50)
-
-      status_after = AlertQueue.get_queue_status(pid)
-      assert status_after.queue_length == 0
+      assert_eventually(fn ->
+        AlertQueue.get_queue_status(pid).queue_length == 0
+      end)
     end
   end
 


### PR DESCRIPTION
## Summary
- Added `assert_eventually/2` helper function to `TestHelpers` for polling async conditions
- Replaced `Process.sleep()` calls with proper async assertions in 3 test files:
  - `test/streampai/accounts/user_test.exs` - tier and platform count checks
  - `test/streampai/livestream_manager/alert_queue_test.exs` - queue state changes
  - `test/streampai/stream/stream_action_test.exs` - supervisor initialization

## Test plan
- [x] All modified tests pass consistently (verified with 3 consecutive runs)
- [x] Tests run faster by eliminating arbitrary delays
- [x] lefthook pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)