### PR TITLE
[MEDIUM][I18N] Localize hardcoded placeholder strings in donation page

### DIFF
--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -535,6 +535,14 @@ export const dict: Dictionary = {
 		enterNotificationMessage: "Benachrichtigungstext eingeben...",
 	},
 
+	// Donation page
+	donation: {
+		customAmountPlaceholder: "Eigener Betrag",
+		anonymousPlaceholder: "Anonym",
+		emailPlaceholder: "email@beispiel.de",
+		messagePlaceholder: "Schreib etwas Nettes...",
+	},
+
 	// Contact page
 	contact: {
 		title: "Kontakt",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -546,6 +546,14 @@ export const dict = {
 		enterNotificationMessage: "Enter notification message...",
 	},
 
+	// Donation page
+	donation: {
+		customAmountPlaceholder: "Custom amount",
+		anonymousPlaceholder: "Anonymous",
+		emailPlaceholder: "email@example.com",
+		messagePlaceholder: "Say something nice...",
+	},
+
 	// Contact page
 	contact: {
 		title: "Contact Us",

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -538,6 +538,14 @@ export const dict: Dictionary = {
 		enterNotificationMessage: "Ingresa el mensaje de notificación...",
 	},
 
+	// Donation page
+	donation: {
+		customAmountPlaceholder: "Monto personalizado",
+		anonymousPlaceholder: "Anónimo",
+		emailPlaceholder: "correo@ejemplo.com",
+		messagePlaceholder: "Escribe algo lindo...",
+	},
+
 	// Contact page
 	contact: {
 		title: "Contacto",

--- a/frontend/src/i18n/locales/pl.ts
+++ b/frontend/src/i18n/locales/pl.ts
@@ -532,6 +532,14 @@ export const dict: Dictionary = {
 		enterNotificationMessage: "Wpisz treść powiadomienia...",
 	},
 
+	// Donation page
+	donation: {
+		customAmountPlaceholder: "Własna kwota",
+		anonymousPlaceholder: "Anonimowo",
+		emailPlaceholder: "email@przyklad.pl",
+		messagePlaceholder: "Napisz coś miłego...",
+	},
+
 	// Contact page
 	contact: {
 		title: "Kontakt",

--- a/frontend/src/routes/u/[username].tsx
+++ b/frontend/src/routes/u/[username].tsx
@@ -3,6 +3,7 @@ import { useParams } from "@solidjs/router";
 import { useLiveQuery } from "@tanstack/solid-db";
 import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 import LoadingIndicator from "~/components/LoadingIndicator";
+import { useTranslation } from "~/i18n";
 import { createUserPreferencesCollection } from "~/lib/electric";
 import { createLocalStorageStore } from "~/lib/useLocalStorage";
 import { getPublicProfile } from "~/sdk/ash_rpc";
@@ -14,6 +15,7 @@ type StreamerPrefs = {
 };
 
 export default function DonationPage() {
+	const { t } = useTranslation();
 	const params = useParams<{ username: string }>();
 	const [userId, setUserId] = createSignal<string | null>(null);
 	const [error, setError] = createSignal<string | null>(null);
@@ -325,7 +327,7 @@ export default function DonationPage() {
 													selectedAmount: null,
 												});
 											}}
-											placeholder="Custom amount"
+											placeholder={t("donation.customAmountPlaceholder")}
 											type="text"
 											value={currentStreamerPrefs().customAmount}
 										/>
@@ -376,7 +378,7 @@ export default function DonationPage() {
 											onInput={(e) =>
 												setDonorInfo("name", e.currentTarget.value)
 											}
-											placeholder="Anonymous"
+											placeholder={t("donation.anonymousPlaceholder")}
 											type="text"
 											value={donorInfo.name}
 										/>
@@ -392,7 +394,7 @@ export default function DonationPage() {
 											onInput={(e) =>
 												setDonorInfo("email", e.currentTarget.value)
 											}
-											placeholder="email@example.com"
+											placeholder={t("donation.emailPlaceholder")}
 											type="email"
 											value={donorInfo.email}
 										/>
@@ -408,7 +410,7 @@ export default function DonationPage() {
 											onInput={(e) =>
 												updateStreamerPrefs({ message: e.currentTarget.value })
 											}
-											placeholder="Say something nice..."
+											placeholder={t("donation.messagePlaceholder")}
 											rows={3}
 											value={currentStreamerPrefs().message}
 										/>


### PR DESCRIPTION
## Summary
- Added translation keys to all 4 locale files (en, de, pl, es) under `donation:` section
- Updated public donation page (`/u/[username]`) to use `t()` translation function for placeholder strings
- Localized 4 hardcoded English placeholders: custom amount, anonymous name, email example, message

## Changes
| Placeholder | EN | DE | PL | ES |
|-------------|-----|-----|-----|-----|
| Custom amount | Custom amount | Eigener Betrag | Własna kwota | Monto personalizado |
| Name | Anonymous | Anonym | Anonim | Anónimo |
| Email | email@example.com | email@beispiel.de | email@przyklad.pl | correo@ejemplo.com |
| Message | Say something nice... | Schreib etwas Nettes... | Napisz coś miłego... | Escribe algo lindo... |

## Test plan
- [x] `bun test src/i18n/locales/locales.test.ts` passes - all locale keys match
- [x] TypeScript typecheck passes
- [x] `lefthook run pre-commit` passes
- [x] Page loads correctly (verified with Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)