### PR TITLE
[MEDIUM][I18N] Localize hardcoded placeholder strings in StreamControlsWidget

### DIFF
--- a/frontend/src/components/stream/LiveStreamControlCenter.tsx
+++ b/frontend/src/components/stream/LiveStreamControlCenter.tsx
@@ -7,6 +7,7 @@ import {
 	onCleanup,
 	onMount,
 } from "solid-js";
+import { useTranslation } from "~/i18n";
 import { SchemaForm } from "~/lib/schema-form/SchemaForm";
 import { badge, button, input } from "~/styles/design-system";
 import { ActivityRow } from "./ActivityRow";
@@ -53,6 +54,7 @@ interface LiveStreamControlCenterProps
 }
 
 export function LiveStreamControlCenter(props: LiveStreamControlCenterProps) {
+	const { t } = useTranslation();
 	const [chatMessage, setChatMessage] = createSignal("");
 	const [selectedPlatforms, setSelectedPlatforms] = createSignal<Set<Platform>>(
 		new Set(props.connectedPlatforms || AVAILABLE_PLATFORMS),
@@ -469,7 +471,7 @@ export function LiveStreamControlCenter(props: LiveStreamControlCenterProps) {
 								class="w-full rounded border border-gray-200 bg-gray-50 px-2 py-1 pr-6 text-xs placeholder:text-gray-400 focus:border-purple-300 focus:bg-white focus:outline-none"
 								data-testid="search-input"
 								onInput={(e) => setSearchText(e.currentTarget.value)}
-								placeholder="Search by name or message..."
+								placeholder={t("stream.searchByNameOrMessage")}
 								type="text"
 								value={searchText()}
 							/>
@@ -680,7 +682,7 @@ export function LiveStreamControlCenter(props: LiveStreamControlCenterProps) {
 							class={`${input.text} flex-1`}
 							onInput={(e) => setChatMessage(e.currentTarget.value)}
 							onKeyDown={handleKeyDown}
-							placeholder="Send a message to chat..."
+							placeholder={t("stream.sendMessageToChat")}
 							type="text"
 							value={chatMessage()}
 						/>

--- a/frontend/src/components/stream/PreStreamSettings.tsx
+++ b/frontend/src/components/stream/PreStreamSettings.tsx
@@ -1,4 +1,5 @@
 import { For, Show, createSignal } from "solid-js";
+import { useTranslation } from "~/i18n";
 import { badge, button, input, text } from "~/styles/design-system";
 import {
 	STREAM_CATEGORIES,
@@ -18,6 +19,7 @@ interface PreStreamSettingsProps {
 }
 
 export function PreStreamSettings(props: PreStreamSettingsProps) {
+	const { t } = useTranslation();
 	const [tagInput, setTagInput] = createSignal("");
 
 	const addTag = () => {
@@ -63,7 +65,7 @@ export function PreStreamSettings(props: PreStreamSettingsProps) {
 									title: e.currentTarget.value,
 								})
 							}
-							placeholder="Enter your stream title..."
+							placeholder={t("stream.streamTitlePlaceholder")}
 							type="text"
 							value={props.metadata.title}
 						/>
@@ -82,7 +84,7 @@ export function PreStreamSettings(props: PreStreamSettingsProps) {
 									description: e.currentTarget.value,
 								})
 							}
-							placeholder="Describe your stream..."
+							placeholder={t("stream.streamDescriptionPlaceholder")}
 							rows="3"
 							value={props.metadata.description}
 						/>
@@ -124,7 +126,7 @@ export function PreStreamSettings(props: PreStreamSettingsProps) {
 										addTag();
 									}
 								}}
-								placeholder="Add a tag..."
+								placeholder={t("stream.addTagPlaceholder")}
 								type="text"
 								value={tagInput()}
 							/>

--- a/frontend/src/components/stream/TimersPanel.tsx
+++ b/frontend/src/components/stream/TimersPanel.tsx
@@ -1,4 +1,5 @@
 import { For, Show, createSignal } from "solid-js";
+import { useTranslation } from "~/i18n";
 import { button, input } from "~/styles/design-system";
 import type { StreamTimer, TimerActionCallbacks } from "./types";
 
@@ -8,6 +9,7 @@ interface TimersPanelProps extends TimerActionCallbacks {
 }
 
 export function TimersPanel(props: TimersPanelProps) {
+	const { t } = useTranslation();
 	const [showAddForm, setShowAddForm] = createSignal(false);
 	const [newTimerLabel, setNewTimerLabel] = createSignal("");
 	const [newTimerContent, setNewTimerContent] = createSignal("");
@@ -180,7 +182,7 @@ export function TimersPanel(props: TimersPanelProps) {
 									class={`${input.text} mt-1 w-full`}
 									data-testid="new-timer-label"
 									onInput={(e) => setNewTimerLabel(e.currentTarget.value)}
-									placeholder="e.g., Social Links, Discord, etc."
+									placeholder={t("stream.timerLabelPlaceholder")}
 									type="text"
 									value={newTimerLabel()}
 								/>
@@ -193,7 +195,7 @@ export function TimersPanel(props: TimersPanelProps) {
 									class={`${input.textarea} mt-1 w-full`}
 									data-testid="new-timer-content"
 									onInput={(e) => setNewTimerContent(e.currentTarget.value)}
-									placeholder="Message to send at each interval..."
+									placeholder={t("stream.timerMessagePlaceholder")}
 									rows="2"
 									value={newTimerContent()}
 								/>

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -128,6 +128,11 @@ export const dict: Dictionary = {
 	stream: {
 		streamTitlePlaceholder: "Titel deines Streams...",
 		streamDescriptionPlaceholder: "Beschreibe deinen Stream...",
+		addTagPlaceholder: "Tag hinzufügen...",
+		searchByNameOrMessage: "Nach Name oder Nachricht suchen...",
+		sendMessageToChat: "Nachricht an den Chat senden...",
+		timerLabelPlaceholder: "z.B. Social Media, Discord usw.",
+		timerMessagePlaceholder: "Nachricht für jedes Intervall...",
 	},
 
 	// Chat History page

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -126,6 +126,11 @@ export const dict = {
 	stream: {
 		streamTitlePlaceholder: "Enter your stream title...",
 		streamDescriptionPlaceholder: "Describe your stream...",
+		addTagPlaceholder: "Add a tag...",
+		searchByNameOrMessage: "Search by name or message...",
+		sendMessageToChat: "Send a message to chat...",
+		timerLabelPlaceholder: "e.g., Social Links, Discord, etc.",
+		timerMessagePlaceholder: "Message to send at each interval...",
 	},
 
 	// Chat History page

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -128,6 +128,11 @@ export const dict: Dictionary = {
 	stream: {
 		streamTitlePlaceholder: "Ingresa el título del stream...",
 		streamDescriptionPlaceholder: "Describe tu stream...",
+		addTagPlaceholder: "Agregar etiqueta...",
+		searchByNameOrMessage: "Buscar por nombre o mensaje...",
+		sendMessageToChat: "Enviar mensaje al chat...",
+		timerLabelPlaceholder: "ej. Redes sociales, Discord, etc.",
+		timerMessagePlaceholder: "Mensaje a enviar en cada intervalo...",
 	},
 
 	// Chat History page

--- a/frontend/src/i18n/locales/pl.ts
+++ b/frontend/src/i18n/locales/pl.ts
@@ -128,6 +128,11 @@ export const dict: Dictionary = {
 	stream: {
 		streamTitlePlaceholder: "Wpisz tytuł streama...",
 		streamDescriptionPlaceholder: "Opisz swój stream...",
+		addTagPlaceholder: "Dodaj tag...",
+		searchByNameOrMessage: "Szukaj po nazwie lub treści...",
+		sendMessageToChat: "Wyślij wiadomość na czat...",
+		timerLabelPlaceholder: "np. Social media, Discord itp.",
+		timerMessagePlaceholder: "Wiadomość do wysłania w każdym interwale...",
 	},
 
 	// Chat History page


### PR DESCRIPTION
## Summary
- Localize 7 hardcoded English placeholder strings in stream control components
- Added translation keys to all 4 locale files (en, de, pl, es) under the `stream` section
- Components now use the `t()` function from `useTranslation` hook

## Changes
**Locale files** (`frontend/src/i18n/locales/`):
- Added 5 new translation keys: `addTagPlaceholder`, `searchByNameOrMessage`, `sendMessageToChat`, `timerLabelPlaceholder`, `timerMessagePlaceholder`

**Components updated**:
- `PreStreamSettings.tsx`: title, description, and tag placeholders
- `LiveStreamControlCenter.tsx`: search and chat message placeholders
- `TimersPanel.tsx`: timer label and message placeholders

## Test plan
- [x] `bun test locales.test.ts` passes - validates all locale files have matching keys
- [x] `bun run typecheck` passes
- [x] `lefthook run pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)